### PR TITLE
Generalize message passing to handle Tuples and NamedTuples

### DIFF
--- a/docs/src/messagepassing.md
+++ b/docs/src/messagepassing.md
@@ -1,4 +1,21 @@
 # Message Passing
 
-TODO
+The message passing is initiated by [`propagate`](@ref)
+and can be customized for a specific layer by overloading the methods
+[`compute_message`](@ref), [`update_node`](@ref), and [`update_edge`](@ref).
 
+
+The message passing corresponds to the following operations 
+
+```math
+\begin{aligned}
+\mathbf{m}_{j\to i} &= \phi(\mathbf{x}_i, \mathbf{x}_j, \mathbf{e}_{j\to i}) \\
+\mathbf{x}_{i}' &= \gamma_x(\mathbf{x}_{i}, \square_{j\in N(i)}  \mathbf{m}_{j\to i})\\
+\mathbf{e}_{j\to i}^\prime &=  \gamma_e(\mathbf{e}_{j \to i},\mathbf{m}_{j \to i})
+\end{aligned}
+```
+where ``phi`` is expressed by the [`compute_message`](@ref) function, 
+``\gamma_x`` and ``gamma_v`` by [`update_node`](@ref) and [`update_edge`](@ref)
+respectively.
+
+See [`GraphConv`](ref) and [`GATConv`](ref)'s implementations as usage examples. 

--- a/src/gnngraph.jl
+++ b/src/gnngraph.jl
@@ -59,7 +59,7 @@ from the LightGraphs' graph library can be used on it.
 
 # Usage. 
 
-```
+```julia
 using Flux, GraphNeuralNetworks
 
 # Construct from adjacency list representation

--- a/test/msgpass.jl
+++ b/test/msgpass.jl
@@ -132,25 +132,24 @@ import GraphNeuralNetworks: compute_message, update_node, update_edge, propagate
             W
         end
         
-        NewLayerNT(in, out) = NewLayerW{GRAPH_T}(randn(T, out, in))
+        NewLayerNT(in, out) = NewLayerNT{GRAPH_T}(randn(T, out, in))
         
-        function compute_message(l::NewLayerW{GRAPH_T}, di, dj, dij)
-            a = l.W * (di.x .+ dj.x) + dij.e
+        function GraphNeuralNetworks.compute_message(l::NewLayerNT{GRAPH_T}, di, dj, dij)
+            a = l.W * (di.x .+ dj.x .+ dij.e) 
             b = l.W * di.x
             return (; a, b)
         end
-        function update_node(l::NewLayerW{GRAPH_T}, m, x) 
-            return (α=l.W * x + m.a + m.b, β=m)
+        function GraphNeuralNetworks.update_node(l::NewLayerNT{GRAPH_T}, m, d) 
+            return (α=l.W * d.x + m.a + m.b, β=m)
         end
-        function update_edge(l::NewLayerW{GRAPH_T}, m, e) 
+        function GraphNeuralNetworks.update_edge(l::NewLayerNT{GRAPH_T}, m, e) 
             return m.a
         end
 
-        function (::NewLayerNT)(l, g, x, e)
-            x, e = propagate(l, g, (; x), (; e))
+        function (::NewLayerNT{GRAPH_T})(g, x, e)
+            x, e = propagate(l, g, mean, (; x), (; e))
             return x.α .+ x.β.a, e
         end
-
 
         l = NewLayerNT(in_channel, out_channel)
         g = GNNGraph(adj, graph_type=GRAPH_T)


### PR DESCRIPTION
Now the GATConv can be expressed through a single call to propagate.

Also renamed `message` to `compute_message`