### PR TITLE
Adds GATv2 layer

### DIFF
--- a/src/GraphNeuralNetworks.jl
+++ b/src/GraphNeuralNetworks.jl
@@ -50,6 +50,7 @@ export
     ChebConv,
     EdgeConv,
     GATConv,
+    GATv2Conv,
     GatedGraphConv,
     GCNConv,
     GINConv,

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -400,8 +400,8 @@ function GATv2Conv(
     bias::Bool=true,
 )
     in, out = channel
-    dense_i = Dense(in, out; bias=bias, init=init)
-    dense_j = Dense(in, out; bias=bias, init=init)
+    dense_i = Dense(in, out*heads; bias=bias, init=init)
+    dense_j = Dense(in, out*heads; bias=false, init=init)
     if concat
         b = bias ? Flux.create_bias(dense_i.weight, bias, out*heads) : false
     else

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -375,9 +375,9 @@ with ``z_i`` a normalization factor.
 - `concat`: Concatenate layer output or not. If not, layer output is averaged over the heads.
 - `negative_slope`: The parameter of LeakyReLU.
 """
-struct GATv2Conv{T, A, B, C<:AbstractMatrix} <: GNNLayer
-    dense_i::A
-    dense_j::A
+struct GATv2Conv{T, A1, A2, B, C<:AbstractMatrix} <: GNNLayer
+    dense_i::A1
+    dense_j::A2
     bias::B
     a::C
     σ

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -120,7 +120,7 @@
         end
 
         @testset "bias=false" begin
-            @test length(Flux.params(GATv2Conv(2=>3))) == 4
+            @test length(Flux.params(GATv2Conv(2=>3))) == 5
             @test length(Flux.params(GATv2Conv(2=>3, bias=false))) == 3
         end
     end

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -5,9 +5,9 @@
     T = Float32
 
     adj1 =  [0 1 0 1
-            1 0 1 0
-            0 1 0 1
-            1 0 1 0]
+             1 0 1 0
+             0 1 0 1
+             1 0 1 0]
     
     g1 = GNNGraph(adj1, 
             ndata=rand(T, in_channel, N), 
@@ -108,6 +108,23 @@
             @test length(Flux.params(GATConv(2=>3, bias=false))) == 2
         end
     end
+
+    @testset "GATv2Conv" begin
+
+        for heads in (1, 2), concat in (true, false)
+            l = GATv2Conv(in_channel => out_channel; heads, concat)
+            for g in test_graphs
+                test_layer(l, g, rtol=1e-4,
+                    outsize=(concat ? heads*out_channel : out_channel, g.num_nodes))
+            end
+        end
+
+        @testset "bias=false" begin
+            @test length(Flux.params(GATv2Conv(2=>3))) == 4
+            @test length(Flux.params(GATv2Conv(2=>3, bias=false))) == 3
+        end
+    end
+
 
     @testset "GatedGraphConv" begin
         num_layers = 3


### PR DESCRIPTION
Adds GATv2 as from https://arxiv.org/abs/2105.14491.

Did the same thing over at `GeometricFlux.jl` [Pull Request](https://github.com/FluxML/GeometricFlux.jl/pull/259). Just as I was "done"  I stumbled upon this repo and liked the codebase a bit better.

The variable names in `GATv2` deviates a bit from the `GAT` layer, i.e. `weight` -> `W`, and `aWW` -> `eij` to stick a bit closer to the notation in the paper. If you want to keep it consistent across the code base I can revert of course.

Cheers
Andre