### PR TITLE
Fix for quadratic batching in #99

### DIFF
--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -206,7 +206,6 @@ function SparseArrays.blockdiag(g1::GNNGraph, gothers::GNNGraph...)
     end
     return g
 end
-SparseArrays.blockdiag(gs::Vector{GNNGraph}) = SparseArrays.blockdiag(gs...) 
 
 """
     batch(gs::Vector{<:GNNGraph})

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -206,6 +206,7 @@ function SparseArrays.blockdiag(g1::GNNGraph, gothers::GNNGraph...)
     end
     return g
 end
+SparseArrays.blockdiag(gs::Vector{GNNGraph}) = SparseArrays.blockdiag(gs...) 
 
 """
     batch(gs::Vector{<:GNNGraph})
@@ -253,8 +254,33 @@ julia> g12.ndata.x
  1.0  1.0  1.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 ```
 """
-Flux.batch(gs::Vector{<:GNNGraph}) = blockdiag(gs...)
+function Flux.batch(gs::Vector{<:GNNGraph})
+    nodes = [g.num_nodes for g in gs]
 
+    if all(y -> isa(y, COO_T), [g.graph for g in gs] )
+        edge_indices = [edge_index(g) for g in gs]
+        nodesum = cumsum([0, nodes...])[1:end-1]
+        s = reduce(vcat, [ei[1] .+ nodesum[ii] for (ii,ei) in enumerate(edge_indices)])
+        t = reduce(vcat, [ei[2] .+ nodesum[ii] for (ii,ei) in enumerate(edge_indices)])
+        w = reduce(vcat, [get_edge_weight(g) for g in gs])
+        w = w isa Vector{Nothing} ? nothing : w 
+        graph = (s, t, w)
+        graph_indicator = vcat([ones_like(ei[1],Int,nodes[ii]) .+ (ii - 1) for (ii,ei) in enumerate(edge_indices)]...)
+    elseif all(y -> isa(y, ADJMAT_T), [g.graph for g in gs] )
+        graph = blockdiag([g.graph for g in gs]...)
+        graph_indicator = vcat([ones_like(graph,Int,nodes[ii]) .+ (ii - 1) for ii in 1:length(nodes)]...)
+    end
+    
+    GNNGraph(graph,
+        sum(nodes), 
+        sum([g.num_edges for g in gs]),
+        sum([g.num_graphs for g in gs]),
+        graph_indicator,
+        cat_features([g.ndata for g in gs]),
+        cat_features([g.edata for g in gs]),
+        cat_features([g.gdata for g in gs]),
+    )
+end
 
 """
     unbatch(g::GNNGraph)

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -259,8 +259,8 @@ function Flux.batch(gs::Vector{<:GNNGraph})
     if all(y -> isa(y, COO_T), [g.graph for g in gs] )
         edge_indices = [edge_index(g) for g in gs]
         nodesum = cumsum([0, nodes...])[1:end-1]
-        s = reduce(vcat, [ei[1] .+ nodesum[ii] for (ii,ei) in enumerate(edge_indices)])
-        t = reduce(vcat, [ei[2] .+ nodesum[ii] for (ii,ei) in enumerate(edge_indices)])
+        s = cat_features([ei[1] .+ nodesum[ii] for (ii, ei) in enumerate(edge_indices)])
+        t = cat_features([ei[2] .+ nodesum[ii] for (ii, ei) in enumerate(edge_indices)])
         w = reduce(vcat, [get_edge_weight(g) for g in gs])
         w = w isa Vector{Nothing} ? nothing : w 
         graph = (s, t, w)

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -24,6 +24,20 @@ function cat_features(x1::NamedTuple, x2::NamedTuple)
     NamedTuple(k => cat_features(getfield(x1,k), getfield(x2,k)) for k in keys(x1))
 end
 
+function cat_features(xs::Vector{NamedTuple{T1, T2}})  where {T1, T2}
+    symbols = [sort(collect(keys(x))) for x in xs]
+    all(y->y==symbols[1], symbols) || @error "cannot concatenate feature data with different keys"
+    length(xs) == 1 && return xs[1] 
+
+    # concatenate 
+    syms = symbols[1]
+    dims = [max(1, ndims(xs[1][k])) for k in syms] # promote scalar to 1D
+    methods = [dim == 1 ? vcat : hcat for dim in dims] # use optimized reduce(hcat,xs) or reduce(vcat,xs)
+    NamedTuple(
+        k => reduce(methods[ii],[x[k] for x in xs]) for (ii,k) in enumerate(syms)
+    )
+end
+
 # Turns generic type into named tuple
 normalize_graphdata(data::Nothing; kws...) = NamedTuple()
 

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -24,7 +24,7 @@ function cat_features(x1::NamedTuple, x2::NamedTuple)
     NamedTuple(k => cat_features(getfield(x1,k), getfield(x2,k)) for k in keys(x1))
 end
 
-function cat_features(xs::Vector{NamedTuple{T1, T2}})  where {T1, T2}
+function cat_features(xs::Vector{<:NamedTuple})
     symbols = [sort(collect(keys(x))) for x in xs]
     all(y->y==symbols[1], symbols) || @error "cannot concatenate feature data with different keys"
     length(xs) == 1 && return xs[1] 

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -31,10 +31,8 @@ function cat_features(xs::Vector{<:NamedTuple})
 
     # concatenate 
     syms = symbols[1]
-    dims = [max(1, ndims(xs[1][k])) for k in syms] # promote scalar to 1D
-    methods = [dim == 1 ? vcat : hcat for dim in dims] # use optimized reduce(hcat,xs) or reduce(vcat,xs)
     NamedTuple(
-        k => reduce(methods[ii],[x[k] for x in xs]) for (ii,k) in enumerate(syms)
+        k => cat_features([x[k] for x in xs]) for (ii,k) in enumerate(syms)
     )
 end
 

--- a/test/GNNGraphs/transform.jl
+++ b/test/GNNGraphs/transform.jl
@@ -25,6 +25,7 @@
         
         g12 = Flux.batch([g1, g2])
         g12b = blockdiag(g1, g2)
+        @test g12 == g12b
         
         g123 = Flux.batch([g1, g2, g3])
         @test g123.graph_indicator == [fill(1, 10); fill(2, 4); fill(3, 7)]


### PR DESCRIPTION
This PR greatly reduces the time and memory use for `batch`ing large numbers of graphs as described in #99 . The key here was using the optimized `reduce(hcat,...)` and `reduce(vcat,...)` to concatenate a large number of Nd arrays. Timings and memory usage: 

Old Version: 

```julia
using BenchmarkTools
using GraphNeuralNetworks

for ngraphs in 2 .^ (10:12)
    gs = [rand_graph(4, 6, ndata=ones(8, 4)) for _ in 1:ngraphs]
    println("\n=======================\nBatchsize = $ngraphs graphs\n=======================\n")
    b = @benchmark GraphNeuralNetworks.blockdiag($gs...)
    display(b)
end

=======================
Batchsize = 1024 graphs
=======================

BenchmarkTools.Trial: 76 samples with 1 evaluation.
 Range (min … max):  51.236 ms … 117.125 ms  ┊ GC (min … max): 16.32% … 24.58%
 Time  (median):     63.494 ms               ┊ GC (median):    21.49%
 Time  (mean ± σ):   66.366 ms ±  10.085 ms  ┊ GC (mean ± σ):  20.39% ±  3.10%

        ▂▂ ▅▅ █ ▅█ █ █▅     ▂        ▂
  ▅▁▁▁▁▁██▅███████▅█▁████▅▁▁█▅▅▅▅█▅▁▁█▁█▁▁█▁▅▁▅▁▁▁▁▁▁▁▁▅▁▁▁▁▁▅ ▁
  51.2 ms         Histogram: frequency by time         93.7 ms <

 Memory estimate: 196.20 MiB, allocs estimate: 73941.

=======================
Batchsize = 2048 graphs
=======================

BenchmarkTools.Trial: 20 samples with 1 evaluation.
 Range (min … max):  225.263 ms … 300.921 ms  ┊ GC (min … max): 18.52% … 17.75%
 Time  (median):     247.739 ms               ┊ GC (median):    17.96%
 Time  (mean ± σ):   256.413 ms ±  23.805 ms  ┊ GC (mean ± σ):  17.74% ±  0.95%

  ▁    █▁   ▁▁ ▁▁ ▁ █▁   ▁        ▁       ▁       ▁ ▁▁   ▁    ▁
  █▁▁▁▁██▁▁▁██▁██▁█▁██▁▁▁█▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁█▁▁▁▁▁▁▁█▁██▁▁▁█▁▁▁▁█ ▁
  225 ms           Histogram: frequency by time          301 ms <

 Memory estimate: 776.31 MiB, allocs estimate: 149717.

=======================
Batchsize = 4096 graphs
=======================

BenchmarkTools.Trial: 5 samples with 1 evaluation.
 Range (min … max):  922.417 ms …   1.126 s  ┊ GC (min … max): 16.82% … 18.22%
 Time  (median):     976.010 ms              ┊ GC (median):    16.93%
 Time  (mean ± σ):      1.009 s ± 80.602 ms  ┊ GC (mean ± σ):  17.26% ±  0.59%

  █            █ █                      █                    █
  █▁▁▁▁▁▁▁▁▁▁▁▁█▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  922 ms          Histogram: frequency by time          1.13 s <

 Memory estimate: 3.02 GiB, allocs estimate: 301269.
```

New version: 

```julia
using BenchmarkTools
using GraphNeuralNetworks

for ngraphs in 2 .^ (10:12)
    gs = [rand_graph(4, 6, ndata=ones(8, 4)) for _ in 1:ngraphs]
    println("\n=======================\nBatchsize = $ngraphs graphs\n=======================\n")
    b = @benchmark GraphNeuralNetworks.batch($gs)
    display(b)
end

=======================
Batchsize = 1024 graphs
=======================

BenchmarkTools.Trial: 7919 samples with 1 evaluation.
 Range (min … max):  359.600 μs …  15.122 ms  ┊ GC (min … max):  0.00% … 88.54%
 Time  (median):     483.500 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   627.847 μs ± 906.415 μs  ┊ GC (mean ± σ):  17.96% ± 11.83%

  ██▅▂▂▁▁                                                       ▂
  █████████▇▇▅▆▅▅▅▃▄▁▄▁▁▃▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▃▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▆▅▇▆▇ █
  360 μs        Histogram: log(frequency) by time        6.7 ms <

 Memory estimate: 1.38 MiB, allocs estimate: 13389.

=======================
Batchsize = 2048 graphs
=======================

BenchmarkTools.Trial: 3931 samples with 1 evaluation.
 Range (min … max):  727.700 μs … 13.003 ms  ┊ GC (min … max):  0.00% … 82.01%
 Time  (median):       1.033 ms              ┊ GC (median):     0.00%
 Time  (mean ± σ):     1.268 ms ±  1.190 ms  ┊ GC (mean ± σ):  16.59% ± 15.12%

  ▅█▇█▆▃▁▁▁                                                    ▁
  ██████████▇▆▃▅▅▃▄▁▁▃▃▃▃▁▃▁▁▁▁▁▁▁▃▁▁▃▁▃▁▁▁▁▁▁▁▁▁▁▁▁▃▃▆▆▆▇█▇█▇ █
  728 μs        Histogram: log(frequency) by time      7.43 ms <

 Memory estimate: 2.75 MiB, allocs estimate: 26705.

=======================
Batchsize = 4096 graphs
=======================

BenchmarkTools.Trial: 1308 samples with 1 evaluation.
 Range (min … max):  1.877 ms … 36.357 ms  ┊ GC (min … max):  0.00% … 87.78%
 Time  (median):     2.747 ms              ┊ GC (median):     0.00%
 Time  (mean ± σ):   3.809 ms ±  2.920 ms  ┊ GC (mean ± σ):  15.78% ± 18.05%

  ▂▃▆█▇▆▄▂▂▂ ▂▂▂▁▁
  ████████████████▇█▅▆▇▆▆▇▆▅▅▅▆▅▅▁▅▅▅▄▅▆▁▆▆▄▇▆█▇▇▆▅▅▇▆▅▄▅▅▅▄ █
  1.88 ms      Histogram: log(frequency) by time     13.3 ms <

 Memory estimate: 5.50 MiB, allocs estimate: 53343.
```
