### PR TITLE
Typecast GNNGraph.num_nodes to Int

### DIFF
--- a/src/GNNGraphs/convert.jl
+++ b/src/GNNGraphs/convert.jl
@@ -2,7 +2,7 @@
 
 function to_coo(coo::COO_T; dir=:out, num_nodes=nothing, weighted=true)
     s, t, val = coo   
-    num_nodes = isnothing(num_nodes) ? max(maximum(s), maximum(t)) : num_nodes 
+    num_nodes::Int = isnothing(num_nodes) ? max(maximum(s), maximum(t)) : num_nodes 
     @assert isnothing(val) || length(val) == length(s)
     @assert length(s) == length(t)
     if !isempty(s)
@@ -114,7 +114,7 @@ function to_dense(coo::COO_T, T=nothing; dir=:out, num_nodes=nothing, weighted=t
     # `dir` will be ignored since the input `coo` is always in source -> target format.
     # The output will always be a adjmat in :out format (e.g. A[i,j] denotes from i to j)
     s, t, val = coo
-    n = isnothing(num_nodes) ? max(maximum(s), maximum(t)) : num_nodes
+    n::Int = isnothing(num_nodes) ? max(maximum(s), maximum(t)) : num_nodes
     val = isnothing(val) ? eltype(s)(1) : val
     T = T === nothing ? eltype(val) : T
     if !weighted
@@ -164,9 +164,9 @@ function to_sparse(coo::COO_T, T=nothing; dir=:out, num_nodes=nothing, weighted=
         eweight = fill!(similar(s, T), 1)
     end
 
-    num_nodes = isnothing(num_nodes) ? max(maximum(s), maximum(t)) : num_nodes 
+    num_nodes::Int = isnothing(num_nodes) ? max(maximum(s), maximum(t)) : num_nodes 
     A = sparse(s, t, eweight, num_nodes, num_nodes)
-    num_edges = nnz(A)
+    num_edges::Int = nnz(A)
     if eltype(A) != T
         A = T.(A)
     end

--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -168,7 +168,8 @@ function GNNGraph(g::AbstractGraph; kws...)
         # add reverse edges since GNNGraph is directed
         s, t = [s; t], [t; s]    
     end
-    GNNGraph((s, t); num_nodes=Graphs.nv(g), kws...)
+    num_nodes::Int = Graphs.nv(g)
+    GNNGraph((s, t); num_nodes=num_nodes, kws...)
 end
 
 

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -177,7 +177,12 @@
         for e in Graphs.edges(lg)
             i, j = src(e), dst(e)
             @test has_edge(g, i, j)
-            @test has_edge(g, j, i)            
+            @test has_edge(g, j, i)
+        end
+
+        @testset "SimpleGraph{Int32}" begin
+            g = GNNGraph(SimpleGraph{Int32}(6), graph_type=GRAPH_T)
+            @test g.num_nodes == 6
         end
     end
 


### PR DESCRIPTION
Fixes type of `GNNGraph.num_nodes` to `Int`.
Was an issue for the following example:

```julia
using Graphs
using GraphNeuralNetworks

GNNGraph(SimpleGraph{Int32}(6))
```

which would lead to `num_nodes` being of type `Int32`. (and `num_graphs`, `num_edges` were still `Int`).
Added a short comment because you might want to typecast `s`, `t` vectors to `Int`, which would also solve the issue (i guess)

Let me know what you think, or feel free to hijack/adapt the PR and merge :)

Cheers
Andre