### PR TITLE
implement hash for GNNGraph

### DIFF
--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -232,4 +232,7 @@ Flux.Data._nobs(g::GNNGraph) = g.num_graphs
 Flux.Data._getobs(g::GNNGraph, i) = getgraph(g, i)
 
 #########################
-Base.:(==)(g1::GNNGraph, g2::GNNGraph) = all(k -> getfield(g1,k)==getfield(g2,k), fieldnames(typeof(g1)))
+function Base.:(==)(g1::GNNGraph, g2::GNNGraph)
+    g1 === g2 && return true
+    all(k -> getfield(g1, k) == getfield(g2, k), fieldnames(typeof(g1)))
+end

--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -240,6 +240,5 @@ end
 
 function Base.hash(g::T, h::UInt) where T<:GNNGraph
     fs = (getfield(g, k) for k in fieldnames(typeof(g)))
-    foldl((h, f) -> hash(f, h),  fs, init=hash(T, h))
-    # collect(fs)
+    return foldl((h, f) -> hash(f, h),  fs, init=hash(T, h))
 end

--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -232,7 +232,14 @@ Flux.Data._nobs(g::GNNGraph) = g.num_graphs
 Flux.Data._getobs(g::GNNGraph, i) = getgraph(g, i)
 
 #########################
+
 function Base.:(==)(g1::GNNGraph, g2::GNNGraph)
     g1 === g2 && return true
     all(k -> getfield(g1, k) == getfield(g2, k), fieldnames(typeof(g1)))
+end
+
+function Base.hash(g::T, h::UInt) where T<:GNNGraph
+    fs = (getfield(g, k) for k in fieldnames(typeof(g)))
+    foldl((h, f) -> hash(f, h),  fs, init=hash(T, h))
+    # collect(fs)
 end

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -55,7 +55,7 @@ function normalize_graphdata(data::NamedTuple; default_name, n, duplicate_if_nee
     sz = map(x -> x isa AbstractArray ? size(x)[end] : 0, data)
     if duplicate_if_needed 
         # Used to copy edge features on reverse edges    
-        @assert all(s -> s == 0 ||  s == n || s == n÷2, sz)
+        @assert all(s -> s == 0 ||  s == n || s == n÷2, sz)  "Wrong size in last dimension for feature array."
     
         function duplicate(v)
             if v isa AbstractArray && size(v)[end] == n÷2
@@ -65,7 +65,7 @@ function normalize_graphdata(data::NamedTuple; default_name, n, duplicate_if_nee
         end
         data = NamedTuple{keys(data)}(duplicate.(values(data)))
     else
-        @assert all(s -> s == 0 ||  s == n, sz)
+        @assert all(s -> s == 0 ||  s == n, sz) "Wrong size in last dimension for feature array."
     end
     return data
 end

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -251,6 +251,25 @@
         g = GNNGraph(erdos_renyi(10, 20))
         @test g isa Graphs.AbstractGraph
     end
+
+    @testset "==" begin
+        g1 = rand_graph(5, 6, ndata=rand(5), edata=rand(6), graph_type=GRAPH_T)
+        @test g1 == g1
+        @test g1 == deepcopy(g1)
+        @test g1 !== deepcopy(g1)
+        
+        g2 = GNNGraph(g1, graph_type=GRAPH_T)
+        @test g1 == g2
+        @test g1 === g2 # this is true since GNNGraph is immutable
+        
+        g2 = GNNGraph(g1, ndata=rand(5), graph_type=GRAPH_T)
+        @test g1 != g2
+        @test g1 !== g2 # this is true since GNNGraph is immutable
+        
+        g2 = GNNGraph(g1, edata=rand(6), graph_type=GRAPH_T)
+        @test g1 != g2
+        @test g1 !== g2 # this is true since GNNGraph is immutable
+    end
 end
 
 

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -276,9 +276,9 @@
         @test hash(g1) == hash(g1)
         @test hash(g1) == hash(deepcopy(g1))
         @test hash(g1) == hash(GNNGraph(g1, ndata=g1.ndata, graph_type=GRAPH_T))
-        @test hash(g1) == hash(GNNGraph(g1, ndata=g1.ndata))
-        @test hash(g1) != hash(GNNGraph(g1, ndata=rand(5)))
-        @test hash(g1) != hash(GNNGraph(g1, edata=rand(6)))
+        @test hash(g1) == hash(GNNGraph(g1, ndata=g1.ndata, graph_type=GRAPH_T))
+        @test hash(g1) != hash(GNNGraph(g1, ndata=rand(5), graph_type=GRAPH_T))
+        @test hash(g1) != hash(GNNGraph(g1, edata=rand(6), graph_type=GRAPH_T))
     end
 end
 

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -248,7 +248,7 @@
     end
 
     @testset "Graphs.jl integration" begin
-        g = GNNGraph(erdos_renyi(10, 20))
+        g = GNNGraph(erdos_renyi(10, 20), graph_type=GRAPH_T)
         @test g isa Graphs.AbstractGraph
     end
 
@@ -264,11 +264,21 @@
         
         g2 = GNNGraph(g1, ndata=rand(5), graph_type=GRAPH_T)
         @test g1 != g2
-        @test g1 !== g2 # this is true since GNNGraph is immutable
+        @test g1 !== g2
         
         g2 = GNNGraph(g1, edata=rand(6), graph_type=GRAPH_T)
         @test g1 != g2
         @test g1 !== g2 # this is true since GNNGraph is immutable
+    end
+
+    @testset "hash" begin
+        g1 = rand_graph(5, 6, ndata=rand(5), edata=rand(6), graph_type=GRAPH_T)
+        @test hash(g1) == hash(g1)
+        @test hash(g1) == hash(deepcopy(g1))
+        @test hash(g1) == hash(GNNGraph(g1, ndata=g1.ndata, graph_type=GRAPH_T))
+        @test hash(g1) == hash(GNNGraph(g1, ndata=g1.ndata))
+        @test hash(g1) != hash(GNNGraph(g1, ndata=rand(5)))
+        @test hash(g1) != hash(GNNGraph(g1, edata=rand(6)))
     end
 end
 

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -268,7 +268,7 @@
         
         g2 = GNNGraph(g1, edata=rand(6), graph_type=GRAPH_T)
         @test g1 != g2
-        @test g1 !== g2 # this is true since GNNGraph is immutable
+        @test g1 !== g2
     end
 
     @testset "hash" begin

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -98,7 +98,7 @@
         for heads in (1, 2), concat in (true, false)
             l = GATConv(in_channel => out_channel; heads, concat)
             for g in test_graphs
-                test_layer(l, g, rtol=1e-4,
+                test_layer(l, g, rtol=1e-3,
                     outsize=(concat ? heads*out_channel : out_channel, g.num_nodes))
             end
         end
@@ -114,7 +114,7 @@
         for heads in (1, 2), concat in (true, false)
             l = GATv2Conv(in_channel => out_channel; heads, concat)
             for g in test_graphs
-                test_layer(l, g, rtol=1e-4,
+                test_layer(l, g, rtol=1e-3,
                     outsize=(concat ? heads*out_channel : out_channel, g.num_nodes))
             end
         end

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -98,7 +98,7 @@
         for heads in (1, 2), concat in (true, false)
             l = GATConv(in_channel => out_channel; heads, concat)
             for g in test_graphs
-                test_layer(l, g, rtol=1e-3, atol=1e-3,
+                test_layer(l, g, rtol=1e-3, atol=1e-2,
                     outsize=(concat ? heads*out_channel : out_channel, g.num_nodes))
             end
         end
@@ -114,7 +114,7 @@
         for heads in (1, 2), concat in (true, false)
             l = GATv2Conv(in_channel => out_channel; heads, concat)
             for g in test_graphs
-                test_layer(l, g, rtol=1e-3, atol=1e-3,
+                test_layer(l, g, rtol=1e-3, atol=1e-2,
                     outsize=(concat ? heads*out_channel : out_channel, g.num_nodes))
             end
         end

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -98,7 +98,7 @@
         for heads in (1, 2), concat in (true, false)
             l = GATConv(in_channel => out_channel; heads, concat)
             for g in test_graphs
-                test_layer(l, g, rtol=1e-3, atol=1e-2,
+                test_layer(l, g, rtol=1e-4,
                     outsize=(concat ? heads*out_channel : out_channel, g.num_nodes))
             end
         end
@@ -114,7 +114,7 @@
         for heads in (1, 2), concat in (true, false)
             l = GATv2Conv(in_channel => out_channel; heads, concat)
             for g in test_graphs
-                test_layer(l, g, rtol=1e-3, atol=1e-2,
+                test_layer(l, g, rtol=1e-4,
                     outsize=(concat ? heads*out_channel : out_channel, g.num_nodes))
             end
         end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -199,7 +199,7 @@ function test_approx_structs(l, l̄, l̄2; atol=1e-5, rtol=1e-5,
             end
         else
             verbose && println("C")
-            test_approx_structs(x, f̄, f̄2; exclude_grad_fields, broken_grad_fields, verbose)
+            test_approx_structs(x, f̄, f̄2; atol, rtol, exclude_grad_fields, broken_grad_fields, verbose)
         end
     end
     return true


### PR DESCRIPTION
Make sure that `g` and `deepcopy(g)` are hashed the same. This is relevant when graphs are used as dictionary keys (e.g. when used as states in the implementation of the MCTS in AlphaZero.jl).

cc @bhalonen