### PR TITLE
Explicit unbatching

### DIFF
--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -433,8 +433,10 @@ function Flux.unbatch(g::GNNGraph)
     [getgraph(g, i) for i in 1:g.num_graphs]
 end
 
-function Flux.unbatch(g::GNNGraph, x) 
-    return [x[g.graph_indicator .∈ Ref(i)] for i in 1:g.num_graphs]
+function Flux.unbatch(g::GNNGraph, x)
+    changes = g.graph_indicator[1:end-1] .!= g.graph_indicator[2:end]
+    indexes = [0; Array(findall(changes)); length(g.graph_indicator)]
+    return [x[indexes[i]+1:indexes[i+1]] for i in 1:g.num_graphs]
 end
 
 """

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -433,6 +433,9 @@ function Flux.unbatch(g::GNNGraph)
     [getgraph(g, i) for i in 1:g.num_graphs]
 end
 
+function Flux.unbatch(g::GNNGraph, x) 
+    return [x[g.graph_indicator .∈ Ref(i)] for i in 1:g.num_graphs]
+end
 
 """
     getgraph(g::GNNGraph, i; nmap=false)


### PR DESCRIPTION
Adds the possibility of unbatching data only. Follows the notation of explicit input of layers.
```julia
using Flux, GraphNeuralNetworks

function full(batched)
    unbatched = Flux.unbatch(batched)
    return([g.ndata.x] for g in unbatched)
end

function Flux.unbatch(g::GNNGraph, x) 
    return [x[g.graph_indicator .∈ Ref(i)] for i in 1:g.num_graphs]
end

g() = (n = rand(5:10); rand_graph(n, 8, ndata=rand(1,n)))
g_b = Flux.batch([g() for _ in 1:100])

full(g_b)
Flux.unbatch(g_b, g_b.ndata.x)
@time full(g_b);
@time Flux.unbatch(g_b, g_b.ndata.x);
```
```julia
0.001567 seconds (4.20 k allocations: 1.114 MiB)
0.000362 seconds (705 allocations: 457.891 KiB)
```
4x speedup in comparison to full unbatching.

Let me know what you think before I'll add tests and documentation