### PR TITLE
Fix typo in docstring

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -1329,7 +1329,7 @@ The layer performs the following operation:
 \mathbf{h}_i' &= \mathbf{h}_i + \phi_h(\mathbf{h}_i, \mathbf{m}_i)
 \end{aligned}
 ```
-where ``\mathbf{h}_i``, ``\mathbf{x}_i``, ``\mathbf{e}_{j\to i}`` are invariant node features, equivariance node
+where ``\mathbf{h}_i``, ``\mathbf{x}_i``, ``\mathbf{e}_{j\to i}`` are invariant node features, equivariant node
 features, and edge features respectively. ``\phi_e``, ``\phi_h``, and
 ``\phi_x`` are two-layer MLPs. `C` is a constant for normalization,
 computed as ``1/|\mathcal{N}(i)|``.

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -1329,7 +1329,7 @@ The layer performs the following operation:
 \mathbf{h}_i' &= \mathbf{h}_i + \phi_h(\mathbf{h}_i, \mathbf{m}_i)
 \end{aligned}
 ```
-where ``\mathbf{h}_i``, ``\mathbf{x}_i``, ``\mathbef{e}_{j\to i}`` are invariant node features, equivariance node
+where ``\mathbf{h}_i``, ``\mathbf{x}_i``, ``\mathbf{e}_{j\to i}`` are invariant node features, equivariance node
 features, and edge features respectively. ``\phi_e``, ``\phi_h``, and
 ``\phi_x`` are two-layer MLPs. `C` is a constant for normalization,
 computed as ``1/|\mathcal{N}(i)|``.


### PR DESCRIPTION
This PR corrects a typo in the latex part of the docstring of the EGNNConv layer. It led to the following yellow line error:

![image](https://user-images.githubusercontent.com/65721467/203087597-f049a54e-4629-461f-af13-09be7b67f578.png)
