### PR TITLE
Compact print of GNNGraphs

### DIFF
--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -224,13 +224,13 @@ end
 function print_feature(io::IO, feature)
     if !isempty(feature)
         if length(keys(feature)) == 1
-            print(io, "$(keys(feature)[1]): $(size(feature[1])[1])×$(size(feature[1])[2])")
+            print(io, "$(keys(feature)[1]): $(dims2string(size(feature[1])))")
         else
-            print(io, "($(keys(feature)[1]): $(size(feature[1])[1])×$(size(feature[1])[2]), ")
+            print(io, "($(keys(feature)[1]): $(dims2string(size(feature[1]))), ")
             for k in keys(feature)[2:end-1]
-                print(io, "$k: $(size(feature[k])[1])×$(size(feature[k])[2]), ")
+                print(io, "$k: $(dims2string(size(feature[k]))), ")
             end
-            print(io, "$(keys(feature)[end]): $(size(feature[end])[1])×$(size(feature[end])[2]))")
+            print(io, "$(keys(feature)[end]): $(dims2string(size(feature[end]))))")
         end
     end
 end

--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -5,21 +5,21 @@ https://juliagraphs.org/Graphs.jl/latest/types/#AbstractGraph-Type
 https://juliagraphs.org/Graphs.jl/latest/developing/#Developing-Alternate-Graph-Types
 =============================================#
 
-const COO_T = Tuple{T, T, V} where {T <: AbstractVector{<:Integer}, V}
-const ADJLIST_T = AbstractVector{T} where T <: AbstractVector{<:Integer}
+const COO_T = Tuple{T,T,V} where {T<:AbstractVector{<:Integer},V}
+const ADJLIST_T = AbstractVector{T} where {T<:AbstractVector{<:Integer}}
 const ADJMAT_T = AbstractMatrix
 const SPARSE_T = AbstractSparseMatrix # subset of ADJMAT_T
-const CUMAT_T = Union{CUDA.AnyCuMatrix, CUDA.CUSPARSE.CuSparseMatrix}
+const CUMAT_T = Union{CUDA.AnyCuMatrix,CUDA.CUSPARSE.CuSparseMatrix}
 
 
 """
     GNNGraph(data; [graph_type, ndata, edata, gdata, num_nodes, graph_indicator, dir])
     GNNGraph(g::GNNGraph; [ndata, edata, gdata])
 
-A type representing a graph structure that also stores 
-feature arrays associated to nodes, edges, and the graph itself. 
+A type representing a graph structure that also stores
+feature arrays associated to nodes, edges, and the graph itself.
 
-A `GNNGraph` can be constructed out of different `data` objects 
+A `GNNGraph` can be constructed out of different `data` objects
 expressing the connections inside the graph. The internal representation type
 is determined by `graph_type`.
 
@@ -28,7 +28,7 @@ is preserved and shared. The node/edge/graph features are retained
 as well, unless explicitely set by the keyword arguments
 `ndata`, `edata`, and `gdata`.
 
-A `GNNGraph` can also represent multiple graphs batched togheter 
+A `GNNGraph` can also represent multiple graphs batched togheter
 (see [`Flux.batch`](@ref) or [`SparseArrays.blockdiag`](@ref)).
 The field `g.graph_indicator` contains the graph membership
 of each node.
@@ -38,34 +38,34 @@ by a source node and a target node (see [`edge_index`](@ref)).
 Self loops (edges connecting a node to itself) and multiple edges
 (more than one edge between the same pair of nodes) are supported.
 
-A `GNNGraph` is a Graphs.jl's `AbstractGraph`, therefore it supports most 
+A `GNNGraph` is a Graphs.jl's `AbstractGraph`, therefore it supports most
 functionality from that library.
 
-# Arguments 
+# Arguments
 
-- `data`: Some data representing the graph topology. Possible type are 
+- `data`: Some data representing the graph topology. Possible type are
     - An adjacency matrix
     - An adjacency list.
     - A tuple containing the source and target vectors (COO representation)
     - A Graphs.jl' graph.
-- `graph_type`: A keyword argument that specifies 
-                the underlying representation used by the GNNGraph. 
-                Currently supported values are 
-    - `:coo`. Graph represented as a tuple `(source, target)`, such that the `k`-th edge 
+- `graph_type`: A keyword argument that specifies
+                the underlying representation used by the GNNGraph.
+                Currently supported values are
+    - `:coo`. Graph represented as a tuple `(source, target)`, such that the `k`-th edge
               connects the node `source[k]` to node `target[k]`.
               Optionally, also edge weights can be given: `(source, target, weights)`.
     - `:sparse`. A sparse adjacency matrix representation.
-    - `:dense`. A dense adjacency matrix representation.  
+    - `:dense`. A dense adjacency matrix representation.
     Defaults to `:coo`, currently the most supported type.
-- `dir`: The assumed edge direction when given adjacency matrix or adjacency list input data `g`. 
+- `dir`: The assumed edge direction when given adjacency matrix or adjacency list input data `g`.
         Possible values are `:out` and `:in`. Default `:out`.
 - `num_nodes`: The number of nodes. If not specified, inferred from `g`. Default `nothing`.
-- `graph_indicator`: For batched graphs, a vector containing the graph assignment of each node. Default `nothing`.  
+- `graph_indicator`: For batched graphs, a vector containing the graph assignment of each node. Default `nothing`.
 - `ndata`: Node features. An array or named tuple of arrays whose last dimension has size `num_nodes`.
 - `edata`: Edge features. An array or named tuple of arrays whose last dimension has size `num_edges`.
-- `gdata`: Graph features. An array or named tuple of arrays whose last dimension has size `num_graphs`. 
+- `gdata`: Graph features. An array or named tuple of arrays whose last dimension has size `num_graphs`.
 
-# Examples 
+# Examples
 
 ```julia
 using Flux, GraphNeuralNetworks
@@ -76,8 +76,8 @@ g = GNNGraph(data)
 
 # Number of nodes, edges, and batched graphs
 g.num_nodes  # 5
-g.num_edges  # 10 
-g.num_graphs # 1 
+g.num_edges  # 10
+g.num_graphs # 1
 
 # Same graph in COO representation
 s = [1,1,2,2,2,3,4,4,5,5]
@@ -90,7 +90,7 @@ g = GNNGraph(erdos_renyi(100, 20))
 # Add 2 node feature arrays
 g = GNNGraph(g, ndata = (x=rand(100, g.num_nodes), y=rand(g.num_nodes)))
 
-# Add node features and edge features with default names `x` and `e` 
+# Add node features and edge features with default names `x` and `e`
 g = GNNGraph(g, ndata = rand(100, g.num_nodes), edata = rand(16, g.num_edges))
 
 g.ndata.x # or just g.x
@@ -117,19 +117,19 @@ end
 
 @functor GNNGraph
 
-function GNNGraph(data::D; 
-                        num_nodes = nothing,
-                        graph_indicator = nothing, 
-                        graph_type = :coo,
-                        dir = :out,
-                        ndata = (;), 
-                        edata = (;), 
-                        gdata = (;),
-                        ) where D <: Union{COO_T, ADJMAT_T, ADJLIST_T}
+function GNNGraph(data::D;
+    num_nodes=nothing,
+    graph_indicator=nothing,
+    graph_type=:coo,
+    dir=:out,
+    ndata=(;),
+    edata=(;),
+    gdata=(;)
+) where {D<:Union{COO_T,ADJMAT_T,ADJLIST_T}}
 
     @assert graph_type ∈ [:coo, :dense, :sparse] "Invalid graph_type $graph_type requested"
     @assert dir ∈ [:in, :out]
-    
+
     if graph_type == :coo
         graph, num_nodes, num_edges = to_coo(data; num_nodes, dir)
     elseif graph_type == :dense
@@ -137,28 +137,28 @@ function GNNGraph(data::D;
     elseif graph_type == :sparse
         graph, num_nodes, num_edges = to_sparse(data; num_nodes, dir)
     end
-    
+
     num_graphs = !isnothing(graph_indicator) ? maximum(graph_indicator) : 1
-    
+
     ndata = normalize_graphdata(ndata, default_name=:x, n=num_nodes)
     edata = normalize_graphdata(edata, default_name=:e, n=num_edges, duplicate_if_needed=true)
     gdata = normalize_graphdata(gdata, default_name=:u, n=num_graphs)
-    
-    GNNGraph(graph, 
-            num_nodes, num_edges, num_graphs, 
-            graph_indicator,
-            ndata, edata, gdata)
+
+    GNNGraph(graph,
+        num_nodes, num_edges, num_graphs,
+        graph_indicator,
+        ndata, edata, gdata)
 end
 
 function (::Type{<:GNNGraph})(num_nodes::T; kws...) where {T<:Integer}
-    s, t = T[], T[] 
+    s, t = T[], T[]
     return GNNGraph(s, t; num_nodes, kws...)
 end
 
-Base.zero(::Type{G}) where G<:GNNGraph = G(0) 
+Base.zero(::Type{G}) where {G<:GNNGraph} = G(0)
 
 # COO convenience constructors
-GNNGraph(s::AbstractVector, t::AbstractVector, v = nothing; kws...) = GNNGraph((s, t, v); kws...)
+GNNGraph(s::AbstractVector, t::AbstractVector, v=nothing; kws...) = GNNGraph((s, t, v); kws...)
 GNNGraph((s, t)::NTuple{2}; kws...) = GNNGraph((s, t, nothing); kws...)
 
 # GNNGraph(g::AbstractGraph; kws...) = GNNGraph(adjacency_matrix(g, dir=:out); kws...)
@@ -166,9 +166,9 @@ GNNGraph((s, t)::NTuple{2}; kws...) = GNNGraph((s, t, nothing); kws...)
 function GNNGraph(g::AbstractGraph; kws...)
     s = Graphs.src.(Graphs.edges(g))
     t = Graphs.dst.(Graphs.edges(g))
-    if !Graphs.is_directed(g) 
+    if !Graphs.is_directed(g)
         # add reverse edges since GNNGraph is directed
-        s, t = [s; t], [t; s]    
+        s, t = [s; t], [t; s]
     end
     num_nodes::Int = Graphs.nv(g)
     GNNGraph((s, t); num_nodes=num_nodes, kws...)
@@ -194,10 +194,10 @@ function GNNGraph(g::GNNGraph; ndata=g.ndata, edata=g.edata, gdata=g.gdata, grap
     else
         graph = g.graph
     end
-    GNNGraph(graph, 
-            g.num_nodes, g.num_edges, g.num_graphs, 
-            g.graph_indicator, 
-            ndata, edata, gdata) 
+    GNNGraph(graph,
+        g.num_nodes, g.num_edges, g.num_graphs,
+        g.graph_indicator,
+        ndata, edata, gdata)
 end
 
 
@@ -209,25 +209,64 @@ otherwise it will be a shallow copy with the same underlying graph data.
 """
 function Base.copy(g::GNNGraph; deep=false)
     if deep
-        GNNGraph(deepcopy(g.graph), 
-                g.num_nodes, g.num_edges, g.num_graphs, 
-                deepcopy(g.graph_indicator), 
-                deepcopy(g.ndata), deepcopy(g.edata), deepcopy(g.gdata))
+        GNNGraph(deepcopy(g.graph),
+            g.num_nodes, g.num_edges, g.num_graphs,
+            deepcopy(g.graph_indicator),
+            deepcopy(g.ndata), deepcopy(g.edata), deepcopy(g.gdata))
     else
-        GNNGraph(g.graph, 
-                g.num_nodes, g.num_edges, g.num_graphs, 
-                g.graph_indicator, 
-                g.ndata, g.edata, g.gdata)
+        GNNGraph(g.graph,
+            g.num_nodes, g.num_edges, g.num_graphs,
+            g.graph_indicator,
+            g.ndata, g.edata, g.gdata)
     end
 end
 
+function print_feature(io::IO, feature)
+    if !isempty(feature)
+        if length(keys(feature)) == 1
+            print(io, "$(keys(feature)[1]): $(size(feature[1])[1])×$(size(feature[1])[2])")
+        else
+            print(io, "($(keys(feature)[1]): $(size(feature[1])[1])×$(size(feature[1])[2]), ")
+            for k in keys(feature)[2:end-1]
+                print(io, "$k: $(size(feature[k])[1])×$(size(feature[k])[2]), ")
+            end
+            print(io, "$(keys(feature)[end]): $(size(feature[end])[1])×$(size(feature[end])[2]))")
+        end
+    end
+end
+
+function print_all_features(io::IO, feat1, feat2, feat3)
+    n1 = length(feat1)
+    n2 = length(feat2)
+    n3 = length(feat3)
+    if n1 == 0 && n2 == 0 && n3 == 0
+        print(io, "no")
+    elseif n1 != 0 && (n2 != 0 || n3 != 0)
+        print_feature(io, feat1)
+        print(io, ", ")
+    elseif n2 == 0 && n3 == 0
+        print_feature(io, feat1)
+    end
+    if n2 != 0 && n3 != 0
+        print_feature(io, feat2)
+        print(io, ", ")
+    elseif n2 != 0 && n3 == 0
+        print_feature(io, feat2)
+    end
+    print_feature(io, feat3)
+end
+
 function Base.show(io::IO, g::GNNGraph)
-    print(io, "GNNGraph($(g.num_nodes), $(g.num_edges))")
+    print(io, "GNNGraph($(g.num_nodes), $(g.num_edges)) with ")
+    print_all_features(io, g.ndata, g.edata, g.gdata)
+    print(io, " data")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", g::GNNGraph)
     if get(io, :compact, false)
-        print(io, "GNNGraph($(g.num_nodes), $(g.num_edges))")
+        print(io, "GNNGraph($(g.num_nodes), $(g.num_edges)) with ")
+        print_all_features(io, g.ndata, g.edata, g.gdata)
+        print(io, " data")
     else # if the following block is indented the printing is ruined
     print(io, "GNNGraph:
   num_nodes: $(g.num_nodes)
@@ -254,7 +293,7 @@ function Base.show(io::IO, ::MIME"text/plain", g::GNNGraph)
     end #else
 end
 
-MLUtils.numobs(g::GNNGraph) = g.num_graphs 
+MLUtils.numobs(g::GNNGraph) = g.num_graphs
 MLUtils.getobs(g::GNNGraph, i) = getgraph(g, i)
 
 
@@ -269,16 +308,16 @@ function Base.:(==)(g1::GNNGraph, g2::GNNGraph)
     return true
 end
 
-function Base.hash(g::T, h::UInt) where T<:GNNGraph
+function Base.hash(g::T, h::UInt) where {T<:GNNGraph}
     fs = (getfield(g, k) for k in fieldnames(typeof(g)) if k !== :graph_indicator)
-    return foldl((h, f) -> hash(f, h),  fs, init=hash(T, h))
+    return foldl((h, f) -> hash(f, h), fs, init=hash(T, h))
 end
 
 function Base.getproperty(g::GNNGraph, s::Symbol)
     if s in fieldnames(GNNGraph)
         return getfield(g, s)
     end
-    if (s in keys(g.ndata)) + (s in keys(g.edata)) + (s in keys(g.gdata)) > 1 
+    if (s in keys(g.ndata)) + (s in keys(g.edata)) + (s in keys(g.gdata)) > 1
         throw(ArgumentError("Ambiguous property name $s"))
     end
     if s in keys(g.ndata)

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -11,7 +11,7 @@ check_num_nodes(::GNNGraph, ::Nothing) = true
 
 function check_num_edges(g::GNNGraph, e::AbstractArray)
     @assert g.num_edges == size(e, ndims(e)) "Got $(size(e, ndims(e))) as last dimension size instead of num_edges=$(g.num_edges)"
-    return true    
+    return true
 end
 function check_num_edges(g::GNNGraph, x::Union{Tuple,NamedTuple})
     map(x -> check_num_edges(g, x), x)
@@ -34,9 +34,9 @@ function sort_edge_index(u::AnyCuArray, v::AnyCuArray)
     sort_edge_index(u |> Flux.cpu, v |> Flux.cpu) |> Flux.gpu
 end
 
-cat_features(x1::Nothing, x2::Nothing) = nothing 
+cat_features(x1::Nothing, x2::Nothing) = nothing
 cat_features(x1::AbstractArray, x2::AbstractArray) = cat(x1, x2, dims=ndims(x1))
-cat_features(x1::Union{Number, AbstractVector}, x2::Union{Number, AbstractVector}) = 
+cat_features(x1::Union{Number, AbstractVector}, x2::Union{Number, AbstractVector}) =
     cat(x1, x2, dims=1)
 
 # workaround for issue #98 #104
@@ -45,12 +45,12 @@ cat_features(xs::AbstractVector{NamedTuple{(), Tuple{}}}) = (;)
 
 function cat_features(x1::NamedTuple, x2::NamedTuple)
     sort(collect(keys(x1))) == sort(collect(keys(x2))) || @error "cannot concatenate feature data with different keys"
-    
+
     NamedTuple(k => cat_features(getfield(x1,k), getfield(x2,k)) for k in keys(x1))
 end
 
 function cat_features(xs::AbstractVector{<:AbstractArray{T,N}}) where {T<:Number, N}
-   cat(xs...; dims=N) 
+   cat(xs...; dims=N)
 end
 
 cat_features(xs::AbstractVector{Nothing}) = nothing
@@ -59,9 +59,9 @@ cat_features(xs::AbstractVector{<:Number}) = xs
 function cat_features(xs::AbstractVector{<:NamedTuple})
     symbols = [sort(collect(keys(x))) for x in xs]
     all(y -> y==symbols[1], symbols) || @error "cannot concatenate feature data with different keys"
-    length(xs) == 1 && return xs[1] 
+    length(xs) == 1 && return xs[1]
 
-    # concatenate 
+    # concatenate
     syms = symbols[1]
     NamedTuple(
         k => cat_features([x[k] for x in xs]) for (ii,k) in enumerate(syms)
@@ -71,8 +71,8 @@ end
 # Turns generic type into named tuple
 normalize_graphdata(data::Nothing; kws...) = NamedTuple()
 
-normalize_graphdata(data; default_name::Symbol, kws...) = 
-    normalize_graphdata(NamedTuple{(default_name,)}((data,)); default_name, kws...) 
+normalize_graphdata(data; default_name::Symbol, kws...) =
+    normalize_graphdata(NamedTuple{(default_name,)}((data,)); default_name, kws...)
 
 function normalize_graphdata(data::NamedTuple; default_name, n, duplicate_if_needed=false)
     # This had to workaround two Zygote bugs with NamedTuples
@@ -82,23 +82,23 @@ function normalize_graphdata(data::NamedTuple; default_name, n, duplicate_if_nee
     if n != 1
         @assert all(x -> x isa AbstractArray, data) "Non-array features provided."
     end
-    
+
     if n == 1
-        # If last array dimension is not 1, add a new dimension. 
+        # If last array dimension is not 1, add a new dimension.
         # This is mostly useful to reshape global feature vectors
         # of size D to Dx1 matrices.
         unsqz_last(v::AbstractArray) = size(v)[end] != 1 ? reshape(v, size(v)..., 1) : v
         unsqz_last(v) = v
-    
+
         data = map(unsqz_last, data)
     end
-    
-    ## Turn vectors in 1 x n matrices. 
+
+    ## Turn vectors in 1 x n matrices.
     # unsqz_first(v::AbstractVector) = reshape(v, 1, length(v))
     # unsqz_first(v) = v
     # data = map(unsqz_first, data)
-    
-    if duplicate_if_needed 
+
+    if duplicate_if_needed
         function duplicate(v)
             if v isa AbstractArray && size(v)[end] == n÷2
                 v = cat(v, v, dims=ndims(v))
@@ -107,12 +107,12 @@ function normalize_graphdata(data::NamedTuple; default_name, n, duplicate_if_nee
         end
         data = map(duplicate, data)
     end
-    
+
     for x in data
         if x isa AbstractArray
             @assert size(x)[end] == n "Wrong size in last dimension for feature array, expected $n but got $(size(x)[end])."
         end
-    end    
+    end
     return data
 end
 
@@ -141,10 +141,10 @@ function edge_encoding(s, t, n; directed=true)
         # directed edges and self-loops allowed
         idx = (s .- 1) .* n .+ t
         maxid = n^2
-    else 
+    else
         # Undirected edges and self-loops allowed
         maxid = n * (n + 1) ÷ 2
-        
+
         mask = s .> t
         snew = copy(s)
         tnew = copy(t)
@@ -152,7 +152,7 @@ function edge_encoding(s, t, n; directed=true)
         tnew[mask] .= s[mask]
         s, t = snew, tnew
 
-        # idx = ∑_{i',i'<i} ∑_{j',j'>=i'}^n 1 + ∑_{j',i<=j'<=j} 1 
+        # idx = ∑_{i',i'<i} ∑_{j',j'>=i'}^n 1 + ∑_{j',i<=j'<=j} 1
         #     = ∑_{i',i'<i} ∑_{j',j'>=i'}^n 1 + (j - i + 1)
         #     = ∑_{i',i'<i} (n - i' + 1) + (j - i + 1)
         #     = (i - 1)*(2*(n+1)-i)÷2 + (j - i + 1)
@@ -169,14 +169,14 @@ function edge_decoding(idx, n; directed=true)
         s =  (idx .- 1) .÷ n .+ 1
         t =  (idx .- 1) .% n .+ 1
     else
-        # We replace j=n in 
-        # idx = (i - 1)*(2*(n+1)-i)÷2 + (j - i + 1) 
+        # We replace j=n in
+        # idx = (i - 1)*(2*(n+1)-i)÷2 + (j - i + 1)
         # and obtain
-        # idx = (i - 1)*(2*(n+1)-i)÷2 + (n - i + 1) 
-        
+        # idx = (i - 1)*(2*(n+1)-i)÷2 + (n - i + 1)
+
         # OR We replace j=i  and obtain??
-        # idx = (i - 1)*(2*(n+1)-i)÷2 + 1 
-        
+        # idx = (i - 1)*(2*(n+1)-i)÷2 + 1
+
         # inverting we have
         s = @. ceil(Int, -sqrt((n + 1/2)^2 - 2*idx) + n + 1/2)
         t = @. idx - (s-1)*(2*(n+1)-s)÷2 - 1 + s
@@ -213,7 +213,7 @@ end
 shortsummary(x) = summary(x)
 shortsummary(x::Number) = "$x"
 
-function shortsummary(x::NamedTuple) 
+function shortsummary(x::NamedTuple)
     if length(x) == 0
         return nothing
     elseif length(x) === 1

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -223,6 +223,7 @@ function shortsummary(x::NamedTuple)
     end
 end
 
+# from (2,2,3) output of size function to a string "2×2×3"
 dims2string(d) = isempty(d) ? "0-dimensional" :
                  length(d) == 1 ? "$(d[1])-element" :
                  join(map(string,d), '×')

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -223,3 +223,7 @@ function shortsummary(x::NamedTuple)
     end
 end
 
+dims2string(d) = isempty(d) ? "0-dimensional" :
+                 length(d) == 1 ? "$(d[1])-element" :
+                 join(map(string,d), '×')
+

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -3,7 +3,7 @@
     @testset "Constructor: adjacency matrix" begin
         A = sprand(10, 10, 0.5)
         sA, tA, vA = findnz(A)
-        
+
         g = GNNGraph(A, graph_type=GRAPH_T)
         s, t = edge_index(g)
         v = get_edge_weight(g)
@@ -19,14 +19,14 @@
         @test v == vA
 
         g = GNNGraph([0 0 0
-                      0 0 1
-                      0 1 0], graph_type=GRAPH_T)
+                0 0 1
+                0 1 0], graph_type=GRAPH_T)
         @test g.num_nodes == 3
         @test g.num_edges == 2
-        
+
         g = GNNGraph([0 1 0
-                      1 0 0
-                      0 0 0], graph_type=GRAPH_T)
+                1 0 0
+                0 0 0], graph_type=GRAPH_T)
         @test g.num_nodes == 3
         @test g.num_edges == 2
     end
@@ -46,12 +46,12 @@
     @testset "symmetric graph" begin
         s = [1, 1, 2, 2, 3, 3, 4, 4]
         t = [2, 4, 1, 3, 2, 4, 1, 3]
-        adj_mat =  [0  1  0  1
-                    1  0  1  0
-                    0  1  0  1
-                    1  0  1  0]
-        adj_list_out =  [[2,4], [1,3], [2,4], [1,3]]
-        adj_list_in =  [[2,4], [1,3], [2,4], [1,3]]
+        adj_mat = [0 1 0 1
+            1 0 1 0
+            0 1 0 1
+            1 0 1 0]
+        adj_list_out = [[2, 4], [1, 3], [2, 4], [1, 3]]
+        adj_list_in = [[2, 4], [1, 3], [2, 4], [1, 3]]
 
         # core functionality
         g = GNNGraph(s, t; graph_type=GRAPH_T)
@@ -64,14 +64,14 @@
         @test nv(g) == g.num_nodes
         @test ne(g) == g.num_edges
         @test Tuple.(collect(edges(g))) |> sort == collect(zip(s, t)) |> sort
-        @test sort(outneighbors(g, 1)) == [2, 4] 
-        @test sort(inneighbors(g, 1)) == [2, 4] 
+        @test sort(outneighbors(g, 1)) == [2, 4]
+        @test sort(inneighbors(g, 1)) == [2, 4]
         @test is_directed(g) == true
         s1, t1 = sort_edge_index(edge_index(g))
         @test s1 == s
         @test t1 == t
         @test vertices(g) == 1:g.num_nodes
-        
+
         @test sort.(adjacency_list(g; dir=:in)) == adj_list_in
         @test sort.(adjacency_list(g; dir=:out)) == adj_list_out
 
@@ -79,28 +79,28 @@
             @test adjacency_matrix(g) == adj_mat
             @test adjacency_matrix(g; dir=:in) == adj_mat
             @test adjacency_matrix(g; dir=:out) == adj_mat
-            
+
             if TEST_GPU
                 # See https://github.com/JuliaGPU/CUDA.jl/pull/1093
                 mat_gpu = adjacency_matrix(g_gpu)
                 @test mat_gpu isa ACUMatrix{Int}
-                @test Array(mat_gpu) == adj_mat 
+                @test Array(mat_gpu) == adj_mat
             end
         end
-        
+
         @testset "normalized_laplacian" begin
             mat = normalized_laplacian(g)
             if TEST_GPU
                 mat_gpu = normalized_laplacian(g_gpu)
                 @test mat_gpu isa ACUMatrix{Float32}
-                @test Array(mat_gpu) == mat 
+                @test Array(mat_gpu) == mat
             end
         end
 
 
         @testset "scaled_laplacian" begin
             if TEST_GPU
-                @test_broken begin 
+                @test_broken begin
                     mat = scaled_laplacian(g)
                     mat_gpu = scaled_laplacian(g_gpu)
                     @test mat_gpu isa ACUMatrix{Float32}
@@ -112,10 +112,10 @@
         @testset "constructors" begin
             adjacency_matrix(g; dir=:out) == adj_mat
             adjacency_matrix(g; dir=:in) == adj_mat
-        end 
+        end
 
         if TEST_GPU
-            @testset "functor" begin                
+            @testset "functor" begin
                 s_cpu, t_cpu = edge_index(g)
                 s_gpu, t_gpu = edge_index(g_gpu)
                 @test s_gpu isa CuVector{Int}
@@ -129,18 +129,18 @@
     @testset "asymmetric graph" begin
         s = [1, 2, 3, 4]
         t = [2, 3, 4, 1]
-        adj_mat_out =  [0  1  0  0
-                        0  0  1  0
-                        0  0  0  1
-                        1  0  0  0]
-        adj_list_out =  [[2], [3], [4], [1]]
+        adj_mat_out = [0 1 0 0
+            0 0 1 0
+            0 0 0 1
+            1 0 0 0]
+        adj_list_out = [[2], [3], [4], [1]]
 
 
-        adj_mat_in =   [0  0  0  1
-                        1  0  0  0
-                        0  1  0  0
-                        0  0  1  0]
-        adj_list_in =  [[4], [1], [2], [3]]
+        adj_mat_in = [0 0 0 1
+            1 0 0 0
+            0 1 0 0
+            0 0 1 0]
+        adj_list_in = [[4], [1], [2], [3]]
 
         # core functionality
         g = GNNGraph(s, t; graph_type=GRAPH_T)
@@ -151,8 +151,8 @@
         @test g.num_edges == 4
         @test g.num_nodes == 4
         @test length(edges(g)) == 4
-        @test sort(outneighbors(g, 1)) == [2] 
-        @test sort(inneighbors(g, 1)) == [4] 
+        @test sort(outneighbors(g, 1)) == [2]
+        @test sort(inneighbors(g, 1)) == [4]
         @test is_directed(g) == true
         @test is_directed(typeof(g)) == true
         s1, t1 = sort_edge_index(edge_index(g))
@@ -160,12 +160,12 @@
         @test t1 == t
 
         # adjacency
-        @test adjacency_matrix(g) ==  adj_mat_out
-        @test adjacency_list(g) ==  adj_list_out
-        @test adjacency_matrix(g, dir=:out) ==  adj_mat_out
-        @test adjacency_list(g, dir=:out) ==  adj_list_out
-        @test adjacency_matrix(g, dir=:in) ==  adj_mat_in
-        @test adjacency_list(g, dir=:in) ==  adj_list_in
+        @test adjacency_matrix(g) == adj_mat_out
+        @test adjacency_list(g) == adj_list_out
+        @test adjacency_matrix(g, dir=:out) == adj_mat_out
+        @test adjacency_list(g, dir=:out) == adj_list_out
+        @test adjacency_matrix(g, dir=:in) == adj_mat_in
+        @test adjacency_list(g, dir=:in) == adj_list_in
     end
 
     @testset "zero" begin
@@ -178,7 +178,7 @@
         lg = random_regular_graph(10, 4)
         @test !Graphs.is_directed(lg)
         g = GNNGraph(lg)
-        @test g.num_edges == 2*ne(lg) # g in undirected
+        @test g.num_edges == 2 * ne(lg) # g in undirected
         @test Graphs.is_directed(g)
         for e in Graphs.edges(lg)
             i, j = src(e), dst(e)
@@ -194,12 +194,12 @@
 
     @testset "Features" begin
         g = GNNGraph(sprand(10, 10, 0.3), graph_type=GRAPH_T)
-        
+
         # default names
         X = rand(10, g.num_nodes)
         E = rand(10, g.num_edges)
         U = rand(10, g.num_graphs)
-        
+
         g = GNNGraph(g, ndata=X, edata=E, gdata=U)
         @test g.ndata.x === X
         @test g.edata.e === E
@@ -237,24 +237,24 @@
 
         # Copy features on reverse edge
         e = rand(30)
-        g = GNNGraph(erdos_renyi(10,  30), edata=e, graph_type=GRAPH_T)
+        g = GNNGraph(erdos_renyi(10, 30), edata=e, graph_type=GRAPH_T)
         @test g.edata.e == [e; e]
 
-        # non-array global 
-        g = rand_graph(10,  30, gdata="ciao", graph_type=GRAPH_T)
+        # non-array global
+        g = rand_graph(10, 30, gdata="ciao", graph_type=GRAPH_T)
         @test g.gdata.u == "ciao"
-    
+
         # vectors stays vectors
-        g = rand_graph(10,  30, ndata=rand(10),
-                                edata=rand(30),
-                                gdata=(u=rand(2), z=rand(1), q=1),
-                                graph_type=GRAPH_T)
+        g = rand_graph(10, 30, ndata=rand(10),
+            edata=rand(30),
+            gdata=(u=rand(2), z=rand(1), q=1),
+            graph_type=GRAPH_T)
         @test size(g.ndata.x) == (10,)
         @test size(g.edata.e) == (30,)
         @test size(g.gdata.u) == (2, 1)
         @test size(g.gdata.z) == (1,)
         @test g.gdata.q === 1
-        
+
         # Error for non-array ndata
         @test_throws AssertionError rand_graph(10,  30, ndata="ciao", graph_type=GRAPH_T)
         @test_throws AssertionError rand_graph(10,  30, ndata=1, graph_type=GRAPH_T)
@@ -271,7 +271,7 @@
         X = rand(10, n)
         E = rand(10, m)
         U = rand(10, 1)
-        data = [rand_graph(n, m, ndata=X, edata=E, gdata=U, graph_type=GRAPH_T) 
+        data = [rand_graph(n, m, ndata=X, edata=E, gdata=U, graph_type=GRAPH_T)
                 for _ in 1:num_graphs]
         g = Flux.batch(data)
 
@@ -279,15 +279,15 @@
             @test MLUtils.getobs(g, 3) == getgraph(g, 3)
             @test MLUtils.getobs(g, 3:5) == getgraph(g, 3:5)
             @test MLUtils.numobs(g) == g.num_graphs
-            
+
             d = Flux.Data.DataLoader(g, batchsize=2, shuffle=false)
             @test first(d) == getgraph(g, 1:2)
         end
 
         @testset "pass to dataloader and no automatic collation" begin
             @test MLUtils.getobs(data, 3) == data[3]
-            @test MLUtils.getobs(data, 3:5) isa Vector{<:GNNGraph} 
-            @test MLUtils.getobs(data, 3:5)  == [data[3], data[4], data[5]]
+            @test MLUtils.getobs(data, 3:5) isa Vector{<:GNNGraph}
+            @test MLUtils.getobs(data, 3:5) == [data[3], data[4], data[5]]
             @test MLUtils.numobs(data) == g.num_graphs
 
             d = Flux.Data.DataLoader(data, batchsize=2, shuffle=false)
@@ -305,15 +305,15 @@
         @test g1 == g1
         @test g1 == deepcopy(g1)
         @test g1 !== deepcopy(g1)
-        
+
         g2 = GNNGraph(g1, graph_type=GRAPH_T)
         @test g1 == g2
         @test g1 === g2 # this is true since GNNGraph is immutable
-        
+
         g2 = GNNGraph(g1, ndata=rand(5), graph_type=GRAPH_T)
         @test g1 != g2
         @test g1 !== g2
-        
+
         g2 = GNNGraph(g1, edata=rand(6), graph_type=GRAPH_T)
         @test g1 != g2
         @test g1 !== g2
@@ -331,14 +331,45 @@
 
 
     @testset "copy" begin
-        g1 = rand_graph(10, 4, ndata=rand(2,10), graph_type=GRAPH_T)
+        g1 = rand_graph(10, 4, ndata=rand(2, 10), graph_type=GRAPH_T)
         g2 = copy(g1)
         @test g1 === g2 # shallow copies are identical for immutable objects
 
         g2 = copy(g1, deep=true)
         @test g1 == g2
-        @test g1 !== g2 
+        @test g1 !== g2
+    end
+
+    @testset "show" begin
+        @test sprint(show, rand_graph(10, 20)) == "GNNGraph(10, 20) with no data"
+        @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10))) == "GNNGraph(10, 20) with x: 5×10 data"
+        @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 3)))) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20, (q: 1×1, p: 3×3) data"
+        @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5, 10),))) == "GNNGraph(10, 20) with a: 5×10 data"
+        @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10), edata=rand(2, 20))) == "GNNGraph(10, 20) with x: 5×10, e: 2×20 data"
+        @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1))) == "GNNGraph(10, 20) with x: 5×10, u: 1×1 data"
+        @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10), edata=(e=rand(2, 20), f=rand(2, 20), h=rand(3, 20)), gdata=rand(1, 1))) == "GNNGraph(10, 20) with x: 5×10, (e: 2×20, f: 2×20, h: 3×20), u: 1×1 data"
+        @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20))) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20 data"
+    end
+
+    @testset "show plain/text compact false" begin
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        x => 5×10 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 3))); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        a => 5×10 Matrix{Float64}\n        b => 3×10 Matrix{Float64}\n    edata:\n        e => 2×20 Matrix{Float64}\n    gdata:\n        q => 1×1 Matrix{Float64}\n        p => 3×3×1 Array{Float64, 3}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10),)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        a => 5×10 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=rand(2, 20)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        x => 5×10 Matrix{Float64}\n    edata:\n        e => 2×20 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        x => 5×10 Matrix{Float64}\n    gdata:\n        u => 1×1 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=(e=rand(2, 20), f=rand(2, 20), h=rand(3, 20)), gdata=rand(1, 1)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        x => 5×10 Matrix{Float64}\n    edata:\n        e => 2×20 Matrix{Float64}\n        f => 2×20 Matrix{Float64}\n        h => 3×20 Matrix{Float64}\n    gdata:\n        u => 1×1 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        a => 5×10 Matrix{Float64}\n        b => 3×10 Matrix{Float64}\n    edata:\n        e => 2×20 Matrix{Float64}"
+    end
+
+    @testset "show plain/text compact true" begin
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20); context=:compact => true) == "GNNGraph(10, 20) with no data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10 data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 3))); context=:compact => true) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20, (q: 1×1, p: 3×3) data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10),)); context=:compact => true) == "GNNGraph(10, 20) with a: 5×10 data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=rand(2, 20)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10, e: 2×20 data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10, u: 1×1 data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=(e=rand(2, 20), f=rand(2, 20), h=rand(3, 20)), gdata=rand(1, 1)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10, (e: 2×20, f: 2×20, h: 3×20), u: 1×1 data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20)); context=:compact => true) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20 data"
     end
 end
-
-

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -349,6 +349,7 @@
         @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1))) == "GNNGraph(10, 20) with x: 5×10, u: 1×1 data"
         @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10), edata=(e=rand(2, 20), f=rand(2, 20), h=rand(3, 20)), gdata=rand(1, 1))) == "GNNGraph(10, 20) with x: 5×10, (e: 2×20, f: 2×20, h: 3×20), u: 1×1 data"
         @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20))) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20 data"
+        @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5,5, 10), b=rand(3,2, 10)), edata=rand(2, 20))) == "GNNGraph(10, 20) with (a: 5×5×10, b: 3×2×10), e: 2×20 data"
     end
 
     @testset "show plain/text compact true" begin

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -361,5 +361,6 @@
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10, u: 1×1 data"
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=(e=rand(2, 20), f=rand(2, 20), h=rand(3, 20)), gdata=rand(1, 1)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10, (e: 2×20, f: 2×20, h: 3×20), u: 1×1 data"
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20)); context=:compact => true) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20 data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5,5, 10), b=rand(3,2, 10)), edata=rand(2, 20)); context=:compact => true) == "GNNGraph(10, 20) with (a: 5×5×10, b: 3×2×10), e: 2×20 data"
     end
 end

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -343,7 +343,7 @@
     @testset "show" begin
         @test sprint(show, rand_graph(10, 20)) == "GNNGraph(10, 20) with no data"
         @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10))) == "GNNGraph(10, 20) with x: 5×10 data"
-        @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 3)))) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20, (q: 1×1, p: 3×3) data"
+        @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 1)))) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20, (q: 1×1, p: 3×1) data"
         @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5, 10),))) == "GNNGraph(10, 20) with a: 5×10 data"
         @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10), edata=rand(2, 20))) == "GNNGraph(10, 20) with x: 5×10, e: 2×20 data"
         @test sprint(show, rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1))) == "GNNGraph(10, 20) with x: 5×10, u: 1×1 data"
@@ -354,7 +354,7 @@
     @testset "show plain/text compact true" begin
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20); context=:compact => true) == "GNNGraph(10, 20) with no data"
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10 data"
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 3))); context=:compact => true) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20, (q: 1×1, p: 3×3) data"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 1))); context=:compact => true) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20, (q: 1×1, p: 3×1) data"
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10),)); context=:compact => true) == "GNNGraph(10, 20) with a: 5×10 data"
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=rand(2, 20)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10, e: 2×20 data"
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10, u: 1×1 data"

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -351,17 +351,6 @@
         @test sprint(show, rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20))) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20 data"
     end
 
-    @testset "show plain/text compact false" begin
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20"
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        x => 5×10 Matrix{Float64}"
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 3))); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        a => 5×10 Matrix{Float64}\n        b => 3×10 Matrix{Float64}\n    edata:\n        e => 2×20 Matrix{Float64}\n    gdata:\n        q => 1×1 Matrix{Float64}\n        p => 3×3×1 Array{Float64, 3}"
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10),)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        a => 5×10 Matrix{Float64}"
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=rand(2, 20)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        x => 5×10 Matrix{Float64}\n    edata:\n        e => 2×20 Matrix{Float64}"
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        x => 5×10 Matrix{Float64}\n    gdata:\n        u => 1×1 Matrix{Float64}"
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=(e=rand(2, 20), f=rand(2, 20), h=rand(3, 20)), gdata=rand(1, 1)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        x => 5×10 Matrix{Float64}\n    edata:\n        e => 2×20 Matrix{Float64}\n        f => 2×20 Matrix{Float64}\n        h => 3×20 Matrix{Float64}\n    gdata:\n        u => 1×1 Matrix{Float64}"
-        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20)); context=:compact => false) == "GNNGraph:\n  num_nodes = 10\n  num_edges = 20\n    ndata:\n        a => 5×10 Matrix{Float64}\n        b => 3×10 Matrix{Float64}\n    edata:\n        e => 2×20 Matrix{Float64}"
-    end
-
     @testset "show plain/text compact true" begin
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20); context=:compact => true) == "GNNGraph(10, 20) with no data"
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10)); context=:compact => true) == "GNNGraph(10, 20) with x: 5×10 data"


### PR DESCRIPTION
 Implementation of the format proposed in issue  #169.
Example:
```julia
julia> [ rand_graph(10,20),
         rand_graph(10,20, ndata=(a=rand(5,10),)),
         rand_graph(10,20, ndata=rand(5,10), edata=rand(2,20), gdata=rand(1,1)),
         rand_graph(10,20, ndata=(a=rand(5,10), b=rand(3,10)), edata=rand(2,20))]

        4-element Vector{GNNGraph{Tuple{Vector{Int64}, Vector{Int64}, Nothing}}}:
         GNNGraph(10, 20) with no data
         GNNGraph(10, 20) with a: 5×10 data
         GNNGraph(10, 20) with x: 5×10, e: 2×20, u: 1×1 data
         GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20 data

```