### PR TITLE
Improve show function

### DIFF
--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -267,30 +267,31 @@ function Base.show(io::IO, ::MIME"text/plain", g::GNNGraph)
         print(io, "GNNGraph($(g.num_nodes), $(g.num_edges)) with ")
         print_all_features(io, g.ndata, g.edata, g.gdata)
         print(io, " data")
-    else # if the following block is indented the printing is ruined
-    print(io, "GNNGraph:
-  num_nodes: $(g.num_nodes)
-  num_edges: $(g.num_edges)")
-  g.num_graphs > 1 && print(io, "\n    num_graphs = $(g.num_graphs)")
-  if !isempty(g.ndata)
-      print(io, "\n  ndata:")
-      for k in keys(g.ndata)
-        print(io, "\n    $k = $(shortsummary(g.ndata[k]))")
-      end
-  end
-  if !isempty(g.edata)
-      print(io, "\n  edata:")
-      for k in keys(g.edata)
-        print(io, "\n    $k = $(shortsummary(g.edata[k]))")
-      end
-  end
-  if !isempty(g.gdata)
-      print(io, "\n  gdata:")
-      for k in keys(g.gdata)
-        print(io, "\n    $k = $(shortsummary(g.gdata[k]))")
-      end
-  end
-    end #else
+    else
+        print(
+            io,
+            "GNNGraph:\n  num_nodes: $(g.num_nodes)\n  num_edges: $(g.num_edges)"
+        )
+        g.num_graphs > 1 && print(io, "\n  num_graphs: $(g.num_graphs)")
+        if !isempty(g.ndata)
+            print(io, "\n  ndata:")
+            for k in keys(g.ndata)
+                print(io, "\n\t$k = $(shortsummary(g.ndata[k]))")
+            end
+        end
+        if !isempty(g.edata)
+            print(io, "\n  edata:")
+            for k in keys(g.edata)
+                print(io, "\n\t$k = $(shortsummary(g.edata[k]))")
+            end
+        end
+        if !isempty(g.gdata)
+            print(io, "\n  gdata:")
+            for k in keys(g.gdata)
+                print(io, "\n\t$k = $(shortsummary(g.gdata[k]))")
+            end
+        end
+    end
 end
 
 MLUtils.numobs(g::GNNGraph) = g.num_graphs

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -363,4 +363,16 @@
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20)); context=:compact => true) == "GNNGraph(10, 20) with (a: 5×10, b: 3×10), e: 2×20 data"
         @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5,5, 10), b=rand(3,2, 10)), edata=rand(2, 20)); context=:compact => true) == "GNNGraph(10, 20) with (a: 5×5×10, b: 3×2×10), e: 2×20 data"
     end
+
+    @testset "show plain/text compact false" begin
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10)); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20\n  ndata:\n\tx = 5×10 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20), gdata=(q=rand(1, 1), p=rand(3, 1))); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20\n  ndata:\n\ta = 5×10 Matrix{Float64}\n\tb = 3×10 Matrix{Float64}\n  edata:\n\te = 2×20 Matrix{Float64}\n  gdata:\n\tq = 1×1 Matrix{Float64}\n\tp = 3×1 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10),)); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20\n  ndata:\n\ta = 5×10 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=rand(2, 20)); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20\n  ndata:\n\tx = 5×10 Matrix{Float64}\n  edata:\n\te = 2×20 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), gdata=rand(1, 1)); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20\n  ndata:\n\tx = 5×10 Matrix{Float64}\n  gdata:\n\tu = 1×1 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=rand(5, 10), edata=(e=rand(2, 20), f=rand(2, 20), h=rand(3, 20)), gdata=rand(1, 1)); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20\n  ndata:\n\tx = 5×10 Matrix{Float64}\n  edata:\n\te = 2×20 Matrix{Float64}\n\tf = 2×20 Matrix{Float64}\n\th = 3×20 Matrix{Float64}\n  gdata:\n\tu = 1×1 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 10), b=rand(3, 10)), edata=rand(2, 20)); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20\n  ndata:\n\ta = 5×10 Matrix{Float64}\n\tb = 3×10 Matrix{Float64}\n  edata:\n\te = 2×20 Matrix{Float64}"
+        @test sprint(show, MIME("text/plain"), rand_graph(10, 20, ndata=(a=rand(5, 5, 10), b=rand(3, 2, 10)), edata=rand(2, 20)); context=:compact => false) == "GNNGraph:\n  num_nodes: 10\n  num_edges: 20\n  ndata:\n\ta = 5×5×10 Array{Float64, 3}\n\tb = 3×2×10 Array{Float64, 3}\n  edata:\n\te = 2×20 Matrix{Float64}"
+    end
 end


### PR DESCRIPTION
With this PR I fix the indentation of the show function, leaving the output almost unchanged. I only added a small change to the indentation of the feature tensors since it looks cleaner this way (I can put the old indentation back if you don't agree). 
Example:
Before 
```jl
GNNGraph:
  num_nodes: 10
  num_edges: 20
  ndata:
    x = 1×10 Matrix{Float64}
  edata:
    a = 1×20 Matrix{Float64}
    b = 3×20 Matrix{Float64}
  gdata:
    u = 2×1 Matrix{Float64}
```

After
```jl
GNNGraph:
  num_nodes: 10
  num_edges: 20
  ndata:
        x = 1×10 Matrix{Float64}
  edata:
        a = 1×20 Matrix{Float64}
        b = 3×20 Matrix{Float64}
  gdata:
        u = 2×1 Matrix{Float64}
```

(in case this PR is fine, I will also align  gnneterographs show function to this format)