### PR TITLE
fixing overflow in GAT layers

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -367,7 +367,9 @@ function message(l::GATConv, Wxi, Wxj, e)
         Wxx = vcat(Wxi, Wxj, We)
     end
     aWW = sum(l.a .* Wxx, dims=1)   # 1 × nheads × nedges
-    α = exp.(leakyrelu.(aWW, l.negative_slope))       
+    logα = leakyrelu.(aWW, l.negative_slope)
+    maxα = maximum(logα)
+    α = exp.(logα .- maxα)       
     return (α = α, β = α .* Wxj)
 end
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -344,7 +344,7 @@ function (l::GATConv)(g::GNNGraph, x::AbstractMatrix, e::Union{Nothing,AbstractM
     Wx = reshape(Wx, chout, heads, :)                   # chout × nheads × nnodes
 
     m = propagate(message, g, +, l; xi=Wx, xj=Wx, e)                 ## chout × nheads × nnodes
-    x = m.β ./ m.α
+    x = m.β ./ (m.α .+ eps(eltype(x))) #
 
     if !l.concat
         x = mean(x, dims=2)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -54,7 +54,7 @@ function softmax_edges(g::GNNGraph, e)
     num = exp.(e .- max_)
     den = reduce_edges(+, g, num)
     den = gather(den, gi)
-    return num ./ den
+    return num ./ (den .+ eps(eltype(e)))
 end
 
 @doc raw"""


### PR DESCRIPTION
I have found that attention in GAT can overflow, as attention layers likes to due to the presence of exp which is not checked for `maximum`. I propose a quick and likely very dirty hack. What I do not like on the solution is that it done in function `message` and works only because there is a subsequent division in other function. I run full test suit and seems to work. 