### PR TITLE
Fix spacing in documentation example

### DIFF
--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -30,7 +30,7 @@ struct GNN                                # step 1
     dense
 end
 
-Flux.@functor GNN                              # step 2
+Flux.@functor GNN                         # step 2
 
 function GNN(din::Int, d::Int, dout::Int) # step 3    
     GNN(GCNConv(din => d),


### PR DESCRIPTION
Quick typo fix