### PR TITLE
improvement for differentiability with heterogeneous graphs

### DIFF
--- a/src/GNNGraphs/GNNGraphs.jl
+++ b/src/GNNGraphs/GNNGraphs.jl
@@ -18,6 +18,8 @@ import MLUtils
 using MLUtils: getobs, numobs
 import Functors
 
+include("chainrules.jl") # hacks for differentiability
+
 include("datastore.jl")
 export DataStore
 

--- a/src/GNNGraphs/chainrules.jl
+++ b/src/GNNGraphs/chainrules.jl
@@ -1,0 +1,15 @@
+# Taken from https://github.com/JuliaDiff/ChainRules.jl/pull/648
+# Remove when merged
+
+function ChainRulesCore.rrule(::Type{T}, ps::Pair...) where {T<:Dict}
+    ks = map(first, ps)
+    project_ks, project_vs = map(ProjectTo, ks), map(ProjectTo∘last, ps)
+    function Dict_pullback(ȳ)
+        dps = map(ks, project_ks, project_vs) do k, proj_k, proj_v
+            dk, dv = proj_k(getkey(ȳ, k, NoTangent())), proj_v(get(ȳ, k, NoTangent()))
+            Tangent{Pair{typeof(dk), typeof(dv)}}(first = dk, second = dv)
+        end
+       return (NoTangent(), dps...)
+    end
+    return T(ps...), Dict_pullback
+end

--- a/src/GNNGraphs/convert.jl
+++ b/src/GNNGraphs/convert.jl
@@ -23,7 +23,7 @@ function to_coo(data::EDict; num_nodes = nothing, kws...)
         _num_nodes[k[1]] = max(get(_num_nodes, k[1], 0), nnodes[1])
         _num_nodes[k[3]] = max(get(_num_nodes, k[3], 0), nnodes[2])
     end
-    graph = Dict(k => v for (k, v) in pairs(graph)) # try to restrict the key/value types
+    graph = Dict([k => v for (k, v) in pairs(graph)]...) # try to restrict the key/value types
     return graph, _num_nodes, num_edges
 end
 

--- a/src/GNNGraphs/gatherscatter.jl
+++ b/src/GNNGraphs/gatherscatter.jl
@@ -1,5 +1,5 @@
 _gather(x::NamedTuple, i) = map(x -> _gather(x, i), x)
-_gather(x::Dict, i) = Dict(k => _gather(v, i) for (k, v) in x)
+_gather(x::Dict, i) = Dict([k => _gather(v, i) for (k, v) in x]...)
 _gather(x::Tuple, i) = map(x -> _gather(x, i), x)
 _gather(x::AbstractArray, i) = NNlib.gather(x, i)
 _gather(x::Nothing, i) = nothing
@@ -7,7 +7,7 @@ _gather(x::Nothing, i) = nothing
 _scatter(aggr, src::Nothing, idx, n) = nothing
 _scatter(aggr, src::NamedTuple, idx, n) = map(s -> _scatter(aggr, s, idx, n), src)
 _scatter(aggr, src::Tuple, idx, n) = map(s -> _scatter(aggr, s, idx, n), src)
-_scatter(aggr, src::Dict, idx, n) = Dict(k => _scatter(aggr, v, idx, n) for (k, v) in src)
+_scatter(aggr, src::Dict, idx, n) = Dict([k => _scatter(aggr, v, idx, n) for (k, v) in src]...)
 
 function _scatter(aggr,
                   src::AbstractArray,

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -163,12 +163,16 @@ function normalize_graphdata(data::NamedTuple; default_name, n, duplicate_if_nee
 end
 
 # For heterogeneous graphs
+function normalize_heterographdata(data::Nothing; default_name::Symbol, ns::Dict, kws...)
+    Dict([k => normalize_graphdata(nothing; default_name = default_name, n, kws...)
+         for (k, n) in ns]...)
+end
+
 normalize_heterographdata(data; kws...) = normalize_heterographdata(Dict(data); kws...)
 
-function normalize_heterographdata(data::Dict; default_name::Symbol, n::Dict, kws...)
-    isempty(data) && return data
-    Dict(k => normalize_graphdata(v; default_name = default_name, n = n[k], kws...)
-         for (k, v) in data)
+function normalize_heterographdata(data::Dict; default_name::Symbol, ns::Dict, kws...)
+    Dict([k => normalize_graphdata(get(data, k, nothing); default_name = default_name, n, kws...)
+         for (k, n) in ns]...)
 end
 
 ones_like(x::AbstractArray, T::Type, sz = size(x)) = fill!(similar(x, T, sz), 1)

--- a/src/layers/heteroconv.jl
+++ b/src/layers/heteroconv.jl
@@ -12,7 +12,7 @@ function HeteroGraphConv(itr; aggr = +)
     return HeteroGraphConv(etypes, layers, aggr)
 end
 
-function (hgc::HeteroGraphConv)(g::GNNHeteroGraph, x::NamedTuple)
+function (hgc::HeteroGraphConv)(g::GNNHeteroGraph, x::Union{NamedTuple,Dict})
     function forw(l, et)
         sg = edge_type_subgraph(g, et)
         node1_t, _, node2_t = et

--- a/test/GNNGraphs/chainrules.jl
+++ b/test/GNNGraphs/chainrules.jl
@@ -1,0 +1,24 @@
+@testset "dict constructor" begin
+    grad = gradient(1.) do x
+        d = Dict([:x => x, :y => 5]...)    
+        return sum(d[:x].^2)
+    end[1]
+
+    @test grad == 2
+
+    ## BROKEN Constructors
+    # grad = gradient(1.) do x
+    #     d = Dict([(:x => x), (:y => 5)])    
+    #     return sum(d[:x].^2)
+    # end[1]
+
+    # @test grad == 2
+
+
+    # grad = gradient(1.) do x
+    #     d = Dict([(:x => x), (:y => 5)])    
+    #     return sum(d[:x].^2)
+    # end[1]
+
+    # @test grad == 2
+end

--- a/test/GNNGraphs/gnnheterograph.jl
+++ b/test/GNNGraphs/gnnheterograph.jl
@@ -14,8 +14,8 @@
     @test hg.num_edges == Dict((:A, :rel1, :B) => 30, (:B, :rel2, :A) => 10)
     @test hg.graph_indicator === nothing
     @test hg.num_graphs == 1
-    @test hg.ndata == Dict()
-    @test hg.edata == Dict()
+    @test hg.ndata isa Dict{Tuple{Symbol, Symbol, Symbol}, DataStore}      
+    @test hg.edata isa Dict{Symbol, DataStore}
     @test isempty(hg.gdata)
     @test sort(hg.ntypes) == [:A, :B]
     @test sort(hg.etypes) == [(:A, :rel1, :B), (:B, :rel2, :A)]

--- a/test/GNNGraphs/gnnheterograph.jl
+++ b/test/GNNGraphs/gnnheterograph.jl
@@ -14,8 +14,8 @@
     @test hg.num_edges == Dict((:A, :rel1, :B) => 30, (:B, :rel2, :A) => 10)
     @test hg.graph_indicator === nothing
     @test hg.num_graphs == 1
-    @test hg.ndata isa Dict{Tuple{Symbol, Symbol, Symbol}, DataStore}      
-    @test hg.edata isa Dict{Symbol, DataStore}
+    @test hg.ndata isa Dict{Symbol, DataStore}
+    @test hg.edata isa Dict{Tuple{Symbol, Symbol, Symbol}, DataStore}
     @test isempty(hg.gdata)
     @test sort(hg.ntypes) == [:A, :B]
     @test sort(hg.etypes) == [(:A, :rel1, :B), (:B, :rel2, :A)]

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -19,3 +19,15 @@
     @test grad.layers[2].weight2 ≈ ngrad.layers[2].weight2  rtol=1e-4
     @test grad.layers[2].bias ≈ ngrad.layers[2].bias        rtol=1e-4
 end
+
+
+GNNHeteroGraph(::Dict{Tuple{Symbol, Symbol, Symbol}, Tuple{Vector{Int64}, Vector{Int64}, Nothing}}, 
+               ::Dict{Symbol, Int64}, 
+               ::Dict{Tuple{Symbol, Symbol, Symbol}, Int64}, 
+               ::Int64, 
+               ::Nothing, 
+               ::Dict{Any, Any}, 
+               ::Dict{Any, Any}, 
+               ::DataStore, 
+               ::Vector{Symbol}, 
+               ::Vector{Tuple{Symbol, Symbol, Symbol}})

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -5,17 +5,26 @@
     model = HeteroGraphConv([(:A,:to,:B) => GraphConv(d => d), 
                             (:B,:to,:A) => GraphConv(d => d)])
 
-    x = (A = rand(Float32, d, n), B = rand(Float32, d, 2n))
+    for x in [
+                (A = rand(Float32, d, n), B = rand(Float32, d, 2n)),
+                Dict(:A => rand(Float32, d, n), :B => rand(Float32, d, 2n)) 
+             ]
+        # x = (A = rand(Float32, d, n), B = rand(Float32, d, 2n))
+        x = Dict(:A => rand(Float32, d, n), :B => rand(Float32, d, 2n)) 
+      
+        y = model(g, x)
 
-    y = model(g, x)
+        grad, dx = gradient((model, x) -> sum(model(g, x)[1]) + sum(model(g, x)[2].^2), model, x)
+        ngrad, ndx = ngradient((model, x) -> sum(model(g, x)[1]) + sum(model(g, x)[2].^2), model, x)
 
-    grad = gradient(model -> sum(model(g, x)[1]) + sum(model(g, x)[2].^2), model)[1]
-    ngrad = ngradient(model -> sum(model(g, x)[1]) + sum(model(g, x)[2].^2), model)[1]
+        @test grad.layers[1].weight1 ≈ ngrad.layers[1].weight1  rtol=1e-4
+        @test grad.layers[1].weight2 ≈ ngrad.layers[1].weight2  rtol=1e-4
+        @test grad.layers[1].bias ≈ ngrad.layers[1].bias        rtol=1e-4
+        @test grad.layers[2].weight1 ≈ ngrad.layers[2].weight1  rtol=1e-4
+        @test grad.layers[2].weight2 ≈ ngrad.layers[2].weight2  rtol=1e-4
+        @test grad.layers[2].bias ≈ ngrad.layers[2].bias        rtol=1e-4
 
-    @test grad.layers[1].weight1 ≈ ngrad.layers[1].weight1  rtol=1e-4
-    @test grad.layers[1].weight2 ≈ ngrad.layers[1].weight2  rtol=1e-4
-    @test grad.layers[1].bias ≈ ngrad.layers[1].bias        rtol=1e-4
-    @test grad.layers[2].weight1 ≈ ngrad.layers[2].weight1  rtol=1e-4
-    @test grad.layers[2].weight2 ≈ ngrad.layers[2].weight2  rtol=1e-4
-    @test grad.layers[2].bias ≈ ngrad.layers[2].bias        rtol=1e-4
+        @test dx[:A] ≈ ndx[:A]        rtol=1e-4
+        @test dx[:B] ≈ ndx[:B]        rtol=1e-4
+    end
 end

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -19,15 +19,3 @@
     @test grad.layers[2].weight2 ≈ ngrad.layers[2].weight2  rtol=1e-4
     @test grad.layers[2].bias ≈ ngrad.layers[2].bias        rtol=1e-4
 end
-
-
-GNNHeteroGraph(::Dict{Tuple{Symbol, Symbol, Symbol}, Tuple{Vector{Int64}, Vector{Int64}, Nothing}}, 
-               ::Dict{Symbol, Int64}, 
-               ::Dict{Tuple{Symbol, Symbol, Symbol}, Int64}, 
-               ::Int64, 
-               ::Nothing, 
-               ::Dict{Any, Any}, 
-               ::Dict{Any, Any}, 
-               ::DataStore, 
-               ::Vector{Symbol}, 
-               ::Vector{Tuple{Symbol, Symbol, Symbol}})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true # for MLDatasets
 include("test_utils.jl")
 
 tests = [
+    "GNNGraphs/chainrules",
     "GNNGraphs/datastore",
     "GNNGraphs/gnngraph",
     "GNNGraphs/convert",

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,9 +1,9 @@
 using ChainRulesTestUtils, FiniteDifferences, Zygote, Adapt, CUDA
 CUDA.allowscalar(false)
 
-function ngradient(f, x)
+function ngradient(f, x...)
     fdm = central_fdm(5, 1)
-    return FiniteDifferences.grad(fdm, f, x)
+    return FiniteDifferences.grad(fdm, f, x...)
 end
 
 const rule_config = Zygote.ZygoteRuleConfig()


### PR DESCRIPTION
The limitations of Zygote in handling dictionaries is a problem for heterographs. 
This improves things a bit by making Dict(::Pairs...) differentiable. 
Predates https://github.com/JuliaDiff/ChainRules.jl/pull/648, to be removed when it is merged.