### PR TITLE
improve add_edges for graph and heterographs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -17,3 +17,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 DemoCards = "0.5.0"
+Documenter = "0.27"

--- a/docs/src/heterograph.md
+++ b/docs/src/heterograph.md
@@ -1,9 +1,8 @@
 # Heterogeneous Graphs
 
 Heterogeneous graphs (also called heterographs), are graphs where each node has a type,
-that we denote with symbols such as `:user` and `:movie`,
-and edges also represent different relations identified
-by a triplet of symbols, `(source_node_type, edge_type, target_node_type)`, as in `(:user, :rate, :movie)`.
+that we denote with symbols such as `:user` and `:movie`.
+Also edges have a type, such as `:rate` or `:like`, and they can connect nodes of different types. We call a triplet `(source_node_type, edge_type, target_node_type)` the type of a *relation*, e.g. `(:user, :rate, :movie)`.
 
 Different node/edge types can store different groups of features
 and this makes heterographs a very flexible modeling tools 
@@ -13,15 +12,21 @@ the type [`GNNHeteroGraph`](@ref).
 
 ## Creating a Heterograph
 
-A heterograph can be created by passing pairs of edge types and data to the constructor.
-```julia-repl
+A heterograph can be created by passing pairs of relation type and data to the constructor.
+```jldoctest
+julia> g = GNNHeteroGraph((:user, :like, :actor) => ([1,2,2,3], [1,3,2,9]),
+                          (:user, :rate, :movie) => ([1,1,2,3], [7,13,5,7]))
+GNNHeteroGraph:
+  num_nodes: Dict(:actor => 9, :movie => 13, :user => 3)
+  num_edges: Dict((:user, :like, :actor) => 4, (:user, :rate, :movie) => 4)
+
 julia> g = GNNHeteroGraph((:user, :rate, :movie) => ([1,1,2,3], [7,13,5,7]))
 GNNHeteroGraph:
   num_nodes: Dict(:movie => 13, :user => 3)
   num_edges: Dict((:user, :rate, :movie) => 4)
 ```
 New relations, possibly with new node types, can be added with the function [`add_edges`](@ref).
-```julia-repl
+```jldoctest
 julia> g = add_edges(g, (:user, :like, :actor) => ([1,2,3,3,3], [3,5,1,9,4]))
 GNNHeteroGraph:
   num_nodes: Dict(:actor => 9, :movie => 13, :user => 3)
@@ -30,7 +35,7 @@ GNNHeteroGraph:
 See [`rand_heterograph`](@ref), [`rand_bipartite_heterograph`](@ref)
 for generating random heterographs. 
 
-```julia-repl
+```jldoctest
 julia> g = rand_bipartite_heterograph((10, 15), 20)
 GNNHeteroGraph:
   num_nodes: Dict(:A => 10, :B => 15)
@@ -40,7 +45,7 @@ GNNHeteroGraph:
 ## Basic Queries
 
 Basic queries are similar to those for homogeneous graphs:
-```julia-repl
+```jldoctest
 julia> g = GNNHeteroGraph((:user, :rate, :movie) => ([1,1,2,3], [7,13,5,7]))
 GNNHeteroGraph:
   num_nodes: Dict(:movie => 13, :user => 3)
@@ -74,7 +79,7 @@ julia> g.etypes
 ## Data Features
 
 Node, edge, and graph features can be added at construction time or later using:
-```julia-repl
+```jldoctest
 # equivalent to g.ndata[:user][:x] = ...
 julia> g[:user].x = rand(Float32, 64, 3);
 
@@ -96,7 +101,7 @@ GNNHeteroGraph:
 
 ## Batching
 Similarly to graphs, also heterographs can be batched together.
-```julia-repl
+```jldoctest
 julia> gs = [rand_bipartite_heterograph((5, 10), 20) for _ in 1:32];
 
 julia> Flux.batch(gs)
@@ -108,7 +113,7 @@ GNNHeteroGraph:
 Batching is automatically performed by the [`DataLoader`](@ref) iterator
 when the `collate` option is set to `true`.
 
-```julia-repl
+```jldoctest
 using Flux: DataLoader
 
 data = [rand_bipartite_heterograph((5, 10), 20, 

--- a/docs/src/temporalgraph.md
+++ b/docs/src/temporalgraph.md
@@ -6,7 +6,7 @@ Temporal Graphs are graphs with time varying topologies and node features. In Gr
 
 A temporal graph can be created by passing a list of snapshots to the constructor. Each snapshot is a [`GNNGraph`](@ref). 
 
-```julia-repl
+```jldoctest
 julia> snapshots = [rand_graph(10,20) for i in 1:5];
 
 julia> tg = TemporalSnapshotsGNNGraph(snapshots)
@@ -18,14 +18,14 @@ TemporalSnapshotsGNNGraph:
 
 A new temporal graph can be created by adding or removing snapshots to an existing temporal graph. 
 
-```julia-repl
+```jldoctest
 julia> new_tg = add_snapshot(tg, 3, rand_graph(10, 16)) # add a new snapshot at time 3
 TemporalSnapshotsGNNGraph:
   num_nodes: [10, 10, 10, 10, 10, 10]
   num_edges: [20, 20, 16, 20, 20, 20]
   num_snapshots: 6
 ```
-```julia-repl
+```jldoctest
 julia> snapshots = [rand_graph(10,20), rand_graph(10,14), rand_graph(10,22)];
 
 julia> tg = TemporalSnapshotsGNNGraph(snapshots)
@@ -43,7 +43,7 @@ TemporalSnapshotsGNNGraph:
 
 See [`rand_temporal_radius_graph`](@ref) and ['rand_temporal_hyperbolic_graph'](@ref) for generating random temporal graphs. 
 
-```julia-repl
+```jldoctest
 julia> tg = rand_temporal_radius_graph(10, 3, 0.1, 0.5)
 TemporalSnapshotsGNNGraph:
   num_nodes: [10, 10, 10]
@@ -54,7 +54,7 @@ TemporalSnapshotsGNNGraph:
 ## Basic Queries
 
 Basic queries are similar to those for [`GNNGraph`](@ref)s:
-```julia-repl
+```jldoctest
 julia> snapshots = [rand_graph(10,20), rand_graph(10,14), rand_graph(10,22)];
 
 julia> tg = TemporalSnapshotsGNNGraph(snapshots)
@@ -94,7 +94,7 @@ GNNGraph:
 
 Node, edge, and graph features can be added at construction time or later using:
 
-```julia-repl
+```jldoctest
 julia> snapshots = [rand_graph(10,20; ndata = rand(3,10)), rand_graph(10,14; ndata = rand(4,10)), rand_graph(10,22; ndata = rand(5,10))]; # node features at construction time
 
 julia> tg = TemporalSnapshotsGNNGraph(snapshots);

--- a/src/GNNGraphs/datastore.jl
+++ b/src/GNNGraphs/datastore.jl
@@ -142,6 +142,8 @@ function Base.show(io::IO, ds::DataStore)
         for (k, v) in getdata(ds)
             print(io, "\n  $(k) = $(summary(v))")
         end
+    else
+        print(io, " with no elements")
     end
 end
 

--- a/src/GNNGraphs/datastore.jl
+++ b/src/GNNGraphs/datastore.jl
@@ -8,7 +8,7 @@ A container for feature arrays. The optional argument `n` enforces that
 At construction time, the `data` can be provided as any iterables of pairs
 of symbols and arrays or as keyword arguments:
 
-```julia-repl
+```jldoctest
 julia> ds = DataStore(3, x = rand(2, 3), y = rand(3))
 DataStore(3) with 2 elements:
   y = 3-element Vector{Float64}
@@ -35,7 +35,7 @@ DataStore() with 2 elements:
 The `DataStore` has an interface similar to both dictionaries and named tuples.
 Arrays can be accessed and added using either the indexing or the property syntax:
 
-```julia-repl
+```jldoctest
 julia> ds = DataStore(x = ones(2, 3), y = zeros(3))
 DataStore() with 2 elements:
   y = 3-element Vector{Float64}
@@ -57,7 +57,7 @@ The `DataStore` can be iterated over, and the keys and values can be accessed
 using `keys(ds)` and `values(ds)`. `map(f, ds)` applies the function `f`
 to each feature array:
 
-```julia-repl
+```jldoctest
 julia> ds = DataStore(a = zeros(2), b = zeros(2));
 
 julia> ds2 = map(x -> x .+ 1, ds)

--- a/src/GNNGraphs/generate.jl
+++ b/src/GNNGraphs/generate.jl
@@ -16,7 +16,7 @@ Additional keyword arguments will be passed to the [`GNNGraph`](@ref) constructo
 
 # Examples
 
-```juliarepl
+```jldoctest
 julia> g = rand_graph(5, 4, bidirected=false)
 GNNGraph:
     num_nodes = 5
@@ -64,7 +64,7 @@ Additional keyword arguments will be passed to the [`GNNHeteroGraph`](@ref) cons
 
 # Examples
 
-```julia-repl
+```jldoctest
 julia> g = rand_heterograph((:user => 10, :movie => 20),
                             (:user, :rate, :movie) => 30)
 GNNHeteroGraph:
@@ -170,7 +170,7 @@ to its `k` closest `points`.
 
 # Examples
 
-```juliarepl
+```jldoctest
 julia> n, k = 10, 3;
 
 julia> x = rand(3, n);
@@ -251,7 +251,7 @@ to its neighbors within a given distance `r`.
 
 # Examples
 
-```juliarepl
+```jldoctest
 julia> n, r = 10, 0.75;
 
 julia> x = rand(3, n);
@@ -331,7 +331,7 @@ If a point happens to move outside the boundary, its position is updated as if i
 
 # Example
 
-```julia-repl
+```jldoctest
 julia> n, snaps, s, r = 10, 5, 0.1, 1.5;
 
 julia> tg = rand_temporal_radius_graph(n,snaps,s,r) # complete graph at each snapshot
@@ -403,7 +403,7 @@ First, the positions of the nodes are generated with a quasi-uniform distributio
 
 # Example
 
-```julia-repl
+```jldoctest
 julia> n, snaps, α, R, speed, ζ = 10, 5, 1.0, 4.0, 0.1, 1.0;
 
 julia> thg = rand_temporal_hyperbolic_graph(n, snaps; α, R, speed, ζ)

--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -153,7 +153,7 @@ function GNNGraph(data::D;
              ndata, edata, gdata)
 end
 
-GNNGraph() = GNNGraph(0)
+GNNGraph(; kws...) = GNNGraph(0; kws...)
 
 function (::Type{<:GNNGraph})(num_nodes::T; kws...) where {T <: Integer}
     s, t = T[], T[]

--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -153,6 +153,8 @@ function GNNGraph(data::D;
              ndata, edata, gdata)
 end
 
+GNNGraph() = GNNGraph(0)
+
 function (::Type{<:GNNGraph})(num_nodes::T; kws...) where {T <: Integer}
     s, t = T[], T[]
     return GNNGraph(s, t; num_nodes, kws...)

--- a/src/GNNGraphs/gnnheterograph.jl
+++ b/src/GNNGraphs/gnnheterograph.jl
@@ -6,6 +6,7 @@ const NDict{T} = Dict{NType, T}
 
 """
     GNNHeteroGraph(data; [ndata, edata, gdata, num_nodes])
+    GNNHeteroGraph(pairs...; [ndata, edata, gdata, num_nodes])
 
 A type representing a heterogeneous graph structure.
 It is similar to [`GNNGraph`](@ref) but nodes and edges are of different types.
@@ -14,6 +15,7 @@ It is similar to [`GNNGraph`](@ref) but nodes and edges are of different types.
 
 - `data`: A dictionary or an iterable object that maps `(source_type, edge_type, target_type)`
           triples to `(source, target)` index vectors (or to `(source, target, weight)` if also edge weights are present).
+- `pairs`: Passing multiple relations as pairs is equivalent to passing `data=Dict(pairs...)`.
 - `ndata`: Node features. A dictionary of arrays or named tuple of arrays.
            The size of the last dimension of each array must be given by `g.num_nodes`.
 - `edata`: Edge features. A dictionary of arrays or named tuple of arrays. Default `nothing`.
@@ -96,6 +98,7 @@ end
 @functor GNNHeteroGraph
 
 GNNHeteroGraph(data; kws...) = GNNHeteroGraph(Dict(data); kws...)
+GNNHeteroGraph(data::Pair...; kws...) = GNNHeteroGraph(Dict(data...); kws...)
 
 function GNNHeteroGraph(data::Dict; kws...)
     all(k -> k isa EType, keys(data)) || throw(ArgumentError("Keys of data must be tuples of the form `(source_type, edge_type, target_type)`"))

--- a/src/GNNGraphs/gnnheterograph.jl
+++ b/src/GNNGraphs/gnnheterograph.jl
@@ -12,18 +12,18 @@ It is similar to [`GNNGraph`](@ref) but nodes and edges are of different types.
 
 # Constructor Arguments
 
-- `data`: A dictionary or an iterable object that maps (source_type, edge_type, target_type)
-    triples to (source, target) index vectors.
+- `data`: A dictionary or an iterable object that maps `(source_type, edge_type, target_type)`
+          triples to `(source, target)` index vectors (or to `(source, target, weight)` if also edge weights are present).
 - `ndata`: Node features. A dictionary of arrays or named tuple of arrays.
            The size of the last dimension of each array must be given by `g.num_nodes`.
-- `edata`: Edge features. A dictionary of arrays or named tuple of arrays.
-           The size of the last dimension of each array must be given by `g.num_edges`.
-- `gdata`: Graph features. An array or named tuple of arrays whose last dimension has size `num_graphs`.
+- `edata`: Edge features. A dictionary of arrays or named tuple of arrays. Default `nothing`.
+           The size of the last dimension of each array must be given by `g.num_edges`. Default `nothing`.
+- `gdata`: Graph features. An array or named tuple of arrays whose last dimension has size `num_graphs`. Default `nothing`.
 - `num_nodes`: The number of nodes for each type. If not specified, inferred from `data`. Default `nothing`.
 
 # Fields
 
-- `graph`: A dictionary that maps `(source_type, edge_type, target_type)`` triples to (source, target) index vectors.
+- `graph`: A dictionary that maps (source_type, edge_type, target_type) triples to (source, target) index vectors.
 - `num_nodes`: The number of nodes for each type.
 - `num_edges`: The number of edges for each type.
 - `ndata`: Node features.
@@ -41,15 +41,15 @@ julia> nA, nB = 10, 20;
 
 julia> num_nodes = Dict(:A => nA, :B => nB);
 
-julia> edges1 = rand(1:nA, 20), rand(1:nB, 20)
+julia> edges1 = (rand(1:nA, 20), rand(1:nB, 20))
 ([4, 8, 6, 3, 4, 7, 2, 7, 3, 2, 3, 4, 9, 4, 2, 9, 10, 1, 3, 9], [6, 4, 20, 8, 16, 7, 12, 16, 5, 4, 6, 20, 11, 19, 17, 9, 12, 2, 18, 12])
 
-julia> edges2 = rand(1:nB, 30), rand(1:nA, 30)
+julia> edges2 = (rand(1:nB, 30), rand(1:nA, 30))
 ([17, 5, 2, 4, 5, 3, 8, 7, 9, 7  …  19, 8, 20, 7, 16, 2, 9, 15, 8, 13], [1, 1, 3, 1, 1, 3, 2, 7, 4, 4  …  7, 10, 6, 3, 4, 9, 1, 5, 8, 5])
 
-julia> eindex = ((:A, :rel1, :B) => edges1, (:B, :rel2, :A) => edges2);
+julia> data = ((:A, :rel1, :B) => edges1, (:B, :rel2, :A) => edges2);
 
-julia> hg = GNNHeteroGraph(eindex; num_nodes)
+julia> hg = GNNHeteroGraph(data; num_nodes)
 GNNHeteroGraph:
   num_nodes: (:A => 10, :B => 20)
   num_edges: ((:A, :rel1, :B) => 20, (:B, :rel2, :A) => 30)
@@ -63,7 +63,7 @@ Dict{Tuple{Symbol, Symbol, Symbol}, Int64} with 2 entries:
 julia> ndata = Dict(:A => (x = rand(2, nA), y = rand(3, num_nodes[:A])),
                     :B => rand(10, nB));
 
-julia> hg = GNNHeteroGraph(eindex; num_nodes, ndata)
+julia> hg = GNNHeteroGraph(data; num_nodes, ndata)
 GNNHeteroGraph:
     num_nodes: (:A => 10, :B => 20)
     num_edges: ((:A, :rel1, :B) => 20, (:B, :rel2, :A) => 30)
@@ -98,7 +98,7 @@ end
 GNNHeteroGraph(data; kws...) = GNNHeteroGraph(Dict(data); kws...)
 
 function GNNHeteroGraph(data::Dict; kws...)
-    all(k -> k isa EType, keys(data)) || throw(ArgumentError("Keys of data must be tuples of the form (source_type, edge_type, target_type)"))
+    all(k -> k isa EType, keys(data)) || throw(ArgumentError("Keys of data must be tuples of the form `(source_type, edge_type, target_type)`"))
     return GNNHeteroGraph(Dict([k => v for (k, v) in pairs(data)]...); kws...)
 end
 

--- a/src/GNNGraphs/query.jl
+++ b/src/GNNGraphs/query.jl
@@ -62,7 +62,7 @@ Return `true` if there is an edge of type `edge_t` from node `i` to node `j` in 
 
 # Examples
 
-```julia-repl
+```jldoctest
 julia> g = rand_bipartite_heterograph((2, 2), (4, 0), bidirected=false)
 GNNHeteroGraph:
   num_nodes: (:A => 2, :B => 2)

--- a/src/GNNGraphs/temporalsnapshotsgnngraph.jl
+++ b/src/GNNGraphs/temporalsnapshotsgnngraph.jl
@@ -77,7 +77,7 @@ Return a `TemporalSnapshotsGNNGraph` created starting from `tg` by adding the sn
 
 # Examples
 
-```julia-repl
+```jldoctest
 julia> using GraphNeuralNetworks
 
 julia> snapshots = [rand_graph(10, 20) for i in 1:5];
@@ -137,7 +137,7 @@ Return a [`TemporalSnapshotsGNNGraph`](@ref) created starting from `tg` by remov
 
 # Examples
 
-```julia-repl
+```jldoctest
 julia> using GraphNeuralNetworks
 
 julia> snapshots = [rand_graph(10,20), rand_graph(10,14), rand_graph(10,22)];

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -118,68 +118,110 @@ end
 
 """
     add_edges(g::GNNGraph, s::AbstractVector, t::AbstractVector; [edata])
+    add_edges(g::GNNGraph, (s, t); [edata])
+    add_edges(g::GNNGraph, (s, t, w); [edata])
 
 Add to graph `g` the edges with source nodes `s` and target nodes `t`.
-Optionally, pass the features  `edata` for the new edges.
+Optionally, pass the edge weight `w` and the features  `edata` for the new edges.
 Returns a new graph sharing part of the underlying data with `g`.
-"""
-function add_edges(g::GNNGraph{<:COO_T},
-                   snew::AbstractVector{<:Integer},
-                   tnew::AbstractVector{<:Integer};
-                   edata = nothing)
-    @assert length(snew) == length(tnew)
-    # TODO remove this constraint
-    @assert get_edge_weight(g) === nothing
 
-    edata = normalize_graphdata(edata, default_name = :e, n = length(snew))
+If the `s` or `t` contain nodes that are not already present in the graph,
+they are added to the graph as well.
+
+# Examples
+
+```juliarepl
+julia> s, t = [1, 2, 3, 3, 4], [2, 3, 4, 4, 4];
+
+julia> w = Float32[1.0, 2.0, 3.0, 4.0, 5.0];
+
+julia> g = GNNGraph((s, t, w))
+GNNGraph:
+  num_nodes: 4
+  num_edges: 5
+
+julia> add_edges(g, ([2, 3], [4, 1], [10.0, 20.0]))
+GNNGraph:
+  num_nodes: 4
+  num_edges: 7
+```
+```juliarepl
+julia> g = GNNGraph()
+GNNGraph:
+    num_nodes: 0
+    num_edges: 0
+
+julia> add_edges(g, [1,2], [2,3])
+GNNGraph:
+    num_nodes: 3
+    num_edges: 2    
+"""
+add_edges(g::GNNGraph{<:COO_T}, snew::AbstractVector, tnew::AbstractVector; kws...) = add_edges(g, (snew, tnew, nothing); kws...)
+add_edges(g, data::Tuple{<:AbstractVector, <:AbstractVector}; kws...) = add_edges(g, (data..., nothing); kws...)
+
+function add_edges(g::GNNGraph{<:COO_T}, data::COO_T; edata = nothing)
+    snew, tnew, wnew = data
+    @assert length(snew) == length(tnew)
+    @assert isnothing(wnew) || length(wnew) == length(snew)
+    @assert minimum(snew) >= 1
+    @assert minimum(tnew) >= 1
+    num_new = length(snew)
+    edata = normalize_graphdata(edata, default_name = :e, n = num_new)
     edata = cat_features(g.edata, edata)
 
     s, t = edge_index(g)
     s = [s; snew]
     t = [t; tnew]
+    w = get_edge_weight(g)
+    w = cat_features(w, wnew, g.num_edges, num_new)
 
-    return GNNGraph((s, t, nothing),
-             g.num_nodes, length(s), g.num_graphs,
+    num_nodes = max(maximum(snew), maximum(tnew), g.num_nodes)
+    if num_nodes > g.num_nodes
+        ndata_new = normalize_graphdata((;), default_name = :x, n = num_nodes - g.num_nodes)
+        ndata = cat_features(g.ndata, ndata_new)
+    else
+        ndata = g.ndata
+    end
+
+    return GNNGraph((s, t, w),
+             num_nodes, length(s), g.num_graphs,
              g.graph_indicator,
-             g.ndata, edata, g.gdata)
+             ndata, edata, g.gdata)
 end
 
-
 """
-    add_edges(g::GNNHeteroGraph, edge_t, s, t; [edata, num_nodes])
-    add_edges(g::GNNHeteroGraph, edge_t => (s, t); [edata, num_nodes])
+    add_edges(g::GNNHeteroGraph, rel_t, s, t; [edata, num_nodes])
+    add_edges(g::GNNHeteroGraph, rel_t => (s, t); [edata, num_nodes])
+    add_edges(g::GNNHeteroGraph, rel_t => (s, t, w); [edata, num_nodes])
 
-Add to heterograph `g` the relation of type `edge_t` with source node vector `s` and target node vector `t`.
-Optionally, pass the features  `edata` for the new edges.
-`edge_t` is a triplet of symbols `(srctype, etype, dsttype)`. 
+Add to heterograph `g` the relation of type `rel_t` with source node vector `s` and target node vector `t`.
+Optionally, pass the  edge weights `w` or the features  `edata` for the new edges.
+`rel_t` is a triplet of symbols `(src_t, edge_t, dst_t)`. 
 
-If the edge type is not already present in the graph, it is added. If it involves new node types, they are added to the graph as well.
+If the relation is not already present in the graph, it is added. If it involves new node types, they are added to the graph as well.
 In this case, a dictionary or named tuple of `num_nodes` can be passed to specify the number of nodes of the new types,
 otherwise the number of nodes is inferred from the maximum node id in `s` and `t`.
 """
-add_edges(g::GNNHeteroGraph{<:COO_T}, data::Pair{EType, <:Tuple}; kws...) = add_edges(g, data.first, data.second...; kws...)
+add_edges(g::GNNHeteroGraph{<:COO_T}, edge_t::EType, snew::AbstractVector, tnew::AbstractVector; kws...) = add_edges(g, edge_t => (snew, tnew, nothing); kws...)
+add_edges(g::GNNHeteroGraph{<:COO_T}, data::Pair{EType, <:Tuple{<:AbstractVector, <:AbstractVector}}; kws...) = add_edges(g, data.first => (data.second..., nothing); kws...)
 
 function add_edges(g::GNNHeteroGraph{<:COO_T},
-                   edge_t::EType,
-                   snew::AbstractVector{<:Integer},
-                   tnew::AbstractVector{<:Integer};
+                   data::Pair{EType, <:COO_T};
                    edata = nothing,
                    num_nodes = Dict{Symbol,Int}())
+    edge_t, (snew, tnew, wnew) = data
     @assert length(snew) == length(tnew)
+    @assert minimum(snew) >= 1
+    @assert minimum(tnew) >= 1
+
     is_existing_rel = haskey(g.graph, edge_t)
-    # TODO remove this constraint
-    if is_existing_rel
-        @assert get_edge_weight(g, edge_t) === nothing
-    end
 
     edata = normalize_graphdata(edata, default_name = :e, n = length(snew))
-    g_edata = g.edata |> copy
-    if !isempty(g.edata)
-        if haskey(g_edata, edge_t)
-            g_edata[edge_t] = cat_features(g.edata[edge_t], edata)
-        else
-            g_edata[edge_t] = edata
-        end
+    _edata = g.edata |> copy
+    if haskey(_edata, edge_t)
+        _edata[edge_t] = cat_features(g.edata[edge_t], edata)
+    else
+        _edata[edge_t] = edata
     end
 
     graph = g.graph |> copy
@@ -204,20 +246,29 @@ function add_edges(g::GNNHeteroGraph{<:COO_T},
         s, t = edge_index(g, edge_t)
         snew = [s; snew]
         tnew = [t; tnew]
+        w = get_edge_weight(g, edge_t)
+        wnew = cat_features(w, wnew, length(s), length(snew))
     end
-    @assert maximum(snew) <= _num_nodes[edge_t[1]]
-    @assert maximum(tnew) <= _num_nodes[edge_t[3]]
-    @assert minimum(snew) >= 1
-    @assert minimum(tnew) >= 1
+    
+    if maximum(snew) > _num_nodes[edge_t[1]]
+        ndata_new = normalize_graphdata((;), default_name = :x, n = maximum(snew) - _num_nodes[edge_t[1]])
+        ndata[edge_t[1]] = cat_features(ndata[edge_t[1]], ndata_new)
+        _num_nodes[edge_t[1]] = maximum(snew)
+    end
+    if maximum(tnew) > _num_nodes[edge_t[3]]
+        ndata_new = normalize_graphdata((;), default_name = :x, n = maximum(tnew) - _num_nodes[edge_t[3]])
+        ndata[edge_t[3]] = cat_features(ndata[edge_t[3]], ndata_new)
+        _num_nodes[edge_t[3]] = maximum(tnew)
+    end
 
-    graph[edge_t] = (snew, tnew, nothing)
+    graph[edge_t] = (snew, tnew, wnew)
     num_edges = g.num_edges |> copy
     num_edges[edge_t] = length(graph[edge_t][1])
 
     return GNNHeteroGraph(graph,
-            _num_nodes, num_edges, g.num_graphs,
+             _num_nodes, num_edges, g.num_graphs,
              g.graph_indicator,
-             g.ndata, g_edata, g.gdata,
+             ndata, _edata, g.gdata,
              ntypes, etypes)
 end
 

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -163,6 +163,9 @@ function add_edges(g::GNNGraph{<:COO_T}, data::COO_T; edata = nothing)
     snew, tnew, wnew = data
     @assert length(snew) == length(tnew)
     @assert isnothing(wnew) || length(wnew) == length(snew)
+    if length(snew) == 0
+        return g
+    end
     @assert minimum(snew) >= 1
     @assert minimum(tnew) >= 1
     num_new = length(snew)
@@ -211,6 +214,9 @@ function add_edges(g::GNNHeteroGraph{<:COO_T},
                    num_nodes = Dict{Symbol,Int}())
     edge_t, (snew, tnew, wnew) = data
     @assert length(snew) == length(tnew)
+    if length(snew) == 0
+        return g
+    end
     @assert minimum(snew) >= 1
     @assert minimum(tnew) >= 1
 

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -130,7 +130,7 @@ they are added to the graph as well.
 
 # Examples
 
-```juliarepl
+```jldoctest
 julia> s, t = [1, 2, 3, 3, 4], [2, 3, 4, 4, 4];
 
 julia> w = Float32[1.0, 2.0, 3.0, 4.0, 5.0];
@@ -145,7 +145,7 @@ GNNGraph:
   num_nodes: 4
   num_edges: 7
 ```
-```juliarepl
+```jldoctest
 julia> g = GNNGraph()
 GNNGraph:
     num_nodes: 0
@@ -301,7 +301,7 @@ See also [`is_bidirected`](@ref).
 
 # Examples
 
-```juliarepl
+```jldoctest
 julia> s, t = [1, 2, 3, 3, 4], [2, 3, 4, 4, 4];
 
 julia> w = [1.0, 2.0, 3.0, 4.0, 5.0];
@@ -491,7 +491,7 @@ See also [`Flux.unbatch`](@ref).
 
 # Examples
 
-```juliarepl
+```jldoctest
 julia> g1 = rand_graph(4, 6, ndata=ones(8, 4))
 GNNGraph:
     num_nodes = 4
@@ -625,7 +625,7 @@ See also [`Flux.batch`](@ref) and [`getgraph`](@ref).
 
 # Examples
 
-```juliarepl
+```jldoctest
 julia> gbatched = Flux.batch([rand_graph(5, 6), rand_graph(10, 8), rand_graph(4,2)])
 GNNGraph:
     num_nodes = 19

--- a/src/GNNGraphs/utils.jl
+++ b/src/GNNGraphs/utils.jl
@@ -55,6 +55,8 @@ function sort_edge_index(u, v)
     return u[p], v[p]
 end
 
+
+
 cat_features(x1::Nothing, x2::Nothing) = nothing
 cat_features(x1::AbstractArray, x2::AbstractArray) = cat(x1, x2, dims = ndims(x1))
 function cat_features(x1::Union{Number, AbstractVector}, x2::Union{Number, AbstractVector})
@@ -126,6 +128,12 @@ function cat_features(xs::AbstractVector{<:Dict})
     return Dict([k => cat_features([x[k] for x in xs]) for k in _keys]...)
 end
 
+
+# Used to concatenate edge weights
+cat_features(w1::Nothing, w2::Nothing, n1::Int, n2::Int) = nothing
+cat_features(w1::AbstractVector, w2::Nothing, n1::Int, n2::Int) = cat_features(w1, ones_like(w1, n2))
+cat_features(w1::Nothing, w2::AbstractVector, n1::Int, n2::Int) = cat_features(ones_like(w2, n1), w2)
+cat_features(w1::AbstractVector, w2::AbstractVector, n1::Int, n2::Int) = cat_features(w1, w2)
 
 
 # Turns generic type into named tuple

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -74,7 +74,7 @@ and if names are given, `m[:name] == m[1]` etc.
 
 # Examples
 
-```juliarepl
+```jldoctest
 julia> using Flux, GraphNeuralNetworks
 
 julia> m = GNNChain(GCNConv(2=>5), 
@@ -199,7 +199,7 @@ returns the dot product `x_i ⋅ xj` on each edge.
 
 # Examples 
 
-```juliarepl
+```jldoctest
 julia> g = rand_graph(5, 6)
 GNNGraph:
     num_nodes = 5

--- a/src/layers/heteroconv.jl
+++ b/src/layers/heteroconv.jl
@@ -20,7 +20,7 @@ have to be aggregated using the `aggr` function. The default is to sum the outpu
 
 # Examples 
 
-```julia-repl
+```jldoctest
 julia> g = rand_bipartite_heterograph((10, 15), 20)
 GNNHeteroGraph:
   num_nodes: Dict(:A => 10, :B => 15)

--- a/src/mldatasets.jl
+++ b/src/mldatasets.jl
@@ -7,7 +7,7 @@ Convert a graph dataset from the package MLDatasets.jl into one or many [`GNNGra
 
 # Examples
 
-```julia-repl
+```jldoctest
 julia> using MLDatasets, GraphNeuralNetworks
 
 julia> mldataset2gnngraph(Cora())

--- a/test/GNNGraphs/gnngraph.jl
+++ b/test/GNNGraphs/gnngraph.jl
@@ -39,6 +39,9 @@ end
     g = G(10)
     @test g.num_nodes == 10
     @test g.num_edges == 0
+
+    g = GNNGraph(graph_type = GRAPH_T)
+    @test g.num_nodes == 0
 end
 
 @testset "symmetric graph" begin

--- a/test/GNNGraphs/gnnheterograph.jl
+++ b/test/GNNGraphs/gnnheterograph.jl
@@ -1,10 +1,14 @@
-# d = MovieLens("100k")[1]
-# hg = GNNHeteroGraph(d.edge_indices)
-# @test hg.num_nodes == Dict("movie" => 193609, "user" => 193609)
-# @test hg.num_edges == Dict(("user", "tag", "movie")  => 7366, ("user", "rating", "movie") => 201672)    
-# @test hg.graph_indicator === nothing
 
-# @test hg["user", "tag", "movie"] == (graph = hg.graph[("user", "tag", "movie")], edata = hg.edata[("user", "tag", "movie")])
+@testset "Constructor from pairs" begin
+    hg = GNNHeteroGraph((:A, :e1, :B) => ([1,2,3,4], [3,2,1,5]))
+    @test hg.num_nodes == Dict(:A => 4, :B => 5)
+    @test hg.num_edges == Dict((:A, :e1, :B) => 4)
+
+    hg = GNNHeteroGraph((:A, :e1, :B) => ([1,2,3], [3,2,1]),
+                        (:A, :e2, :C) => ([1,2,3], [4,5,6]))
+    @test hg.num_nodes == Dict(:A => 3, :B => 3, :C => 6)
+    @test hg.num_edges == Dict((:A, :e1, :B) => 3, (:A, :e2, :C) => 3)
+end
 
 @testset "Generation" begin
     hg = rand_heterograph(Dict(:A => 10, :B => 20),
@@ -19,6 +23,7 @@
     @test isempty(hg.gdata)
     @test sort(hg.ntypes) == [:A, :B]
     @test sort(hg.etypes) == [(:A, :rel1, :B), (:B, :rel2, :A)]
+
 end
 
 @testset "features" begin


### PR DESCRIPTION

- Support passing edge weights.
- Allows to add edges with source or target indexes larger then num_nodes. New nodes are created in this case.
- adds the empty graph constructor `GNNGraph()`
 
Fix #331. 