### PR TITLE
Remove `f` from `CGConv` signature

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -881,7 +881,7 @@ function Base.show(io::IO, l::ResGatedGraphConv)
 end
 
 @doc raw"""
-    CGConv((in, ein) => out, f, act=identity; bias=true, init=glorot_uniform, residual=false)
+    CGConv((in, ein) => out, act=identity; bias=true, init=glorot_uniform, residual=false)
     CGConv(in => out, ...)
 
 The crystal graph convolutional layer from the paper


### PR DESCRIPTION
![image](https://github.com/CarloLucibello/GraphNeuralNetworks.jl/assets/65721467/8d40b763-f942-496f-9ce3-d9ec3d40410f)
The f in this signature is not used in the `CGConv` implementation.
