### PR TITLE
fix: fix typos in the docs

### DIFF
--- a/docs/src/api/conv.md
+++ b/docs/src/api/conv.md
@@ -9,7 +9,7 @@ Some of the most commonly used layers are the [`GCNConv`](@ref) and the [`GATv2C
 (see [`GNNChain`](@ref)).
 
 The table below lists all graph convolutional layers implemented in the *GraphNeuralNetworks.jl*. It also highlights the presence of some additional capabilities with respect to basic message passing:
-- *Sparse Ops*: implements message passing as multiplication by sparse adjacency matrix instead of the gather/scatter mechanism. This can lead to better cpu performances but it is not supported on gpu yet. 
+- *Sparse Ops*: implements message passing as multiplication by sparse adjacency matrix instead of the gather/scatter mechanism. This can lead to better CPU performances but it is not supported on GPU yet. 
 - *Edge Weight*: supports scalar weights (or equivalently scalar features) on edges. 
 - *Edge Features*: supports feature vectors on edges.
 - *Heterograph*: supports heterogeneous graphs (see [`GNNHeteroGraphs`](@ref)).

--- a/docs/src/heterograph.md
+++ b/docs/src/heterograph.md
@@ -2,7 +2,7 @@
 
 Heterogeneous graphs (also called heterographs), are graphs where each node has a type,
 that we denote with symbols such as `:user` and `:movie`.
-Releations such as `:rate` or `:like` can connect nodes of different types. We call a triplet `(source_node_type, relation_type, target_node_type)` the type of a edge, e.g. `(:user, :rate, :movie)`.
+Relations such as `:rate` or `:like` can connect nodes of different types. We call a triplet `(source_node_type, relation_type, target_node_type)` the type of a edge, e.g. `(:user, :rate, :movie)`.
 
 Different node/edge types can store different groups of features
 and this makes heterographs a very flexible modeling tools 


### PR DESCRIPTION
This PR fixes a minor typo in the docs as well as capitalizes `gpu` and `cpu` as per the wide used convention.