### PR TITLE
Add `TemporalGraphConv`

### DIFF
--- a/src/GraphNeuralNetworks.jl
+++ b/src/GraphNeuralNetworks.jl
@@ -73,6 +73,7 @@ export
 # layers/temporalconv
       TGCN,
       A3TGCN,
+      TemporalGraphConv,
 
 # layers/pool
       GlobalPool,

--- a/src/layers/temporalconv.jl
+++ b/src/layers/temporalconv.jl
@@ -187,7 +187,6 @@ function Base.show(io::IO, a3tgcn::A3TGCN)
     print(io, "A3TGCN($(a3tgcn.in) => $(a3tgcn.out))")
 end
 
-
 @doc raw"""
     TemporalGraphConv(layer)
 

--- a/src/layers/temporalconv.jl
+++ b/src/layers/temporalconv.jl
@@ -186,3 +186,25 @@ end
 function Base.show(io::IO, a3tgcn::A3TGCN)
     print(io, "A3TGCN($(a3tgcn.in) => $(a3tgcn.out))")
 end
+
+
+# struct to apply convolutional layers to each snapshot of the temporal graph
+
+struct TemporalGraphConv
+    layer::GNNLayer
+end
+
+Flux.@functor TemporalGraphConv
+
+function (tgconv::TemporalGraphConv)(tsg::TemporalSnapshotsGNNGraph)
+    return TemporalSnapshotsGNNGraph(
+        tsg.num_nodes,
+        tsg.num_edges,
+        tsg.num_snapshots,
+        tgconv.layer.(tsg.snapshots),
+        tsg.tgdata)
+end
+
+function (tgconv::TemporalGraphConv)(tsg::TemporalSnapshotsGNNGraph, x)
+        return tgconv.layer.(tsg.snapshots, x)
+end

--- a/src/layers/temporalconv.jl
+++ b/src/layers/temporalconv.jl
@@ -206,7 +206,6 @@ julia> size(temp_gcn(tsg).ndata.x[1])
 (5, 20)
 ```
 """
-
 struct TemporalGraphConv
     layer::GNNLayer
 end

--- a/src/layers/temporalconv.jl
+++ b/src/layers/temporalconv.jl
@@ -188,7 +188,25 @@ function Base.show(io::IO, a3tgcn::A3TGCN)
 end
 
 
-# struct to apply convolutional layers to each snapshot of the temporal graph
+@doc raw"""
+    TemporalGraphConv(layer)
+
+A constructor for applying to each snapshot of the `TemporalSnapshotsGNNGraph` a convolutional homogeneous graph `layer`.
+
+# Examples 
+
+```jldoctest
+julia> snapshots = [rand_graph(20,40; ndata = rand(3,20)), rand_graph(20,14; ndata = rand(3,20)), rand_graph(20,20; ndata = rand(3,20))];
+
+julia> tsg = TemporalSnapshotsGNNGraph(snapshots);
+
+julia> temp_gcn = TemporalGraphConv(GCNConv(3 => 5, relu))
+TemporalGraphConv(GCNConv(3 => 5, relu))
+
+julia> size(temp_gcn(tsg).ndata.x[1])
+(5, 20)
+```
+"""
 
 struct TemporalGraphConv
     layer::GNNLayer

--- a/src/layers/temporalconv.jl
+++ b/src/layers/temporalconv.jl
@@ -206,8 +206,8 @@ julia> size(temp_gcn(tsg).ndata.x[1])
 (5, 20)
 ```
 """
-struct TemporalGraphConv
-    layer::GNNLayer
+struct TemporalGraphConv{L <: GNNLayer}
+    layer::L
 end
 
 Flux.@functor TemporalGraphConv

--- a/test/layers/temporalconv.jl
+++ b/test/layers/temporalconv.jl
@@ -30,3 +30,18 @@ end
     @test size(model(g1, g1.ndata.x)) == (1, N)
     @test model(g1) isa GNNGraph            
 end
+
+@testset "TemporalGraphConv" begin
+    snapshots = [rand_graph(20,40; ndata = rand(3,20)), rand_graph(20,14; ndata = rand(3,20)), rand_graph(20,20; ndata = rand(3,20))]
+    tsg = TemporalSnapshotsGNNGraph(snapshots)
+    
+    AGNN = GraphNeuralNetworks.TemporalGraphConv(AGNNConv())
+    @test size(Flux.gradient(x -> sum(sum(AGNN(tsg, x))), tsg.ndata.x)[1][1]) == (3, 20)
+    @test tsg1 = AGNN(tsg) isa TemporalSnapshotsGNNGraph
+    @test size(AGNN(tsg).snapshots[1].ndata.x) == (3, 20)
+
+    GCN = GraphNeuralNetworks.TemporalGraphConv(GCNConv(3=>5))
+    @test size(Flux.gradient(x -> sum(sum(GCN(tsg, x))), tsg.ndata.x)[1][1]) == (3, 20)
+    @test tsg1 = GCN(tsg) isa TemporalSnapshotsGNNGraph
+    @test size(GCN(tsg).snapshots[1].ndata.x) == (5, 20)
+end;


### PR DESCRIPTION
This PR adds a `TemporalGraphConv` constructor to each snapshot of the `TemporalSnapshotsGNNGraph`, a convolutional homogeneous graph `layer`. 
A PR will follow to update the documentation.