### PR TITLE
refinement: Self loops for HeteroGraph returns g instead of error if src != tgt

### DIFF
--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -57,7 +57,7 @@ function add_self_loops(g::GNNHeteroGraph{Tuple{T, T, V}}, edge_t::EType) where 
 
     src_t, _, tgt_t = edge_t
     (src_t === tgt_t) ||
-        @error "cannot add a self-loop with different source and target types"
+        return g
     
     n = get(g.num_nodes, src_t, 0)
 


### PR DESCRIPTION
This PR changes self loops for HeteroGraph to return g instead of throwing error if src != tgt, as in reality in that case graph doesn't change. This refinement would allow us avoid trycatches or similar mechanism when dealing with conv layers for heterographs.
Also, this unblocks https://github.com/CarloLucibello/GraphNeuralNetworks.jl/pull/367 