### PR TITLE
`g.ndata.e` documentation fix in `GNNGraph` 

### DIFF
--- a/src/GNNGraphs/gnngraph.jl
+++ b/src/GNNGraphs/gnngraph.jl
@@ -95,7 +95,7 @@ g.edata.z = rand(16, g.num_edges)
 g = GNNGraph(g, ndata = rand(100, g.num_nodes), edata = rand(16, g.num_edges))
 
 g.ndata.x # or just g.x
-g.ndata.e # or just g.e
+g.edata.e # or just g.e
 
 # Send to gpu
 g = g |> gpu


### PR DESCRIPTION
Fixed to g.edata.e instead of g.ndata.e [(Issue #380)](https://github.com/CarloLucibello/GraphNeuralNetworks.jl/issues/380)