### PR TITLE
Error in docs

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -1359,8 +1359,8 @@ function Base.show(io::IO, l::SGConv)
 end
 
 @doc raw"""
-    EdgeConv((in, ein) => out; hidden_size=2in, residual=false)
-    EdgeConv(in => out; hidden_size=2in, residual=false)
+    EGNNConv((in, ein) => out; hidden_size=2in, residual=false)
+    EGNNConv(in => out; hidden_size=2in, residual=false)
 
 Equivariant Graph Convolutional Layer from [E(n) Equivariant Graph
 Neural Networks](https://arxiv.org/abs/2102.09844).


### PR DESCRIPTION
[EGNN docs](https://carlolucibello.github.io/GraphNeuralNetworks.jl/dev/api/conv/#GraphNeuralNetworks.EGNNConv) show the code template as `EdgeConv` which is a typo.
Fixed in this PR. 