### PR TITLE
Add EGNNConv support for HeteroGraphConv 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Manifest.toml
 LocalPreferences.toml
 .DS_Store
 /test.jl
+try.jl

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -801,11 +801,10 @@ function SAGEConv(ch::Pair{Int, Int}, σ = identity; aggr = mean,
     SAGEConv(W, b, σ, aggr)
 end
 
-function (l::SAGEConv)(g::AbstractGNNGraph, x)
+function (l::SAGEConv)(g::GNNGraph, x::AbstractMatrix)
     check_num_nodes(g, x)
-    xj, xi = expand_srcdst(g, x)
-    m = propagate(copy_xj, g, l.aggr, xj = xj)
-    x = l.σ.(l.weight * vcat(xi, m) .+ l.bias)
+    m = propagate(copy_xj, g, l.aggr, xj = x)
+    x = l.σ.(l.weight * vcat(x, m) .+ l.bias)
     return x
 end
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -1451,13 +1451,17 @@ function EGNNConv(ch::Pair{NTuple{2, Int}, Int}; hidden_size::Int = 2 * ch[1][1]
     return EGNNConv(ϕe, ϕx, ϕh, num_features, residual)
 end
 
-function (l::EGNNConv)(g::GNNGraph, h::AbstractMatrix, x::AbstractMatrix, e = nothing)
+function (l::EGNNConv)(g::AbstractGNNGraph, h, x, e = nothing)
     if l.num_features.edge > 0
         @assert e!==nothing "Edge features must be provided."
     end
+    
     @assert size(h, 1)==l.num_features.in "Input features must match layer input size."
-
-    x_diff = apply_edges(xi_sub_xj, g, x, x)
+    print("\n\n\n\nPANG\n\n\n\n")
+    xj, xi = expand_srcdst(g, x)
+    #hj, hi = expand_srcdst(g, h) not needed since its invariant node features
+    
+    x_diff = apply_edges(xi_sub_xj, g, xi, xj)
     sqnorm_xdiff = sum(x_diff .^ 2, dims = 1)
     x_diff = x_diff ./ (sqrt.(sqnorm_xdiff) .+ 1.0f-6)
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -1457,7 +1457,6 @@ function (l::EGNNConv)(g::AbstractGNNGraph, h, x, e = nothing)
     end
     
     @assert size(h, 1)==l.num_features.in "Input features must match layer input size."
-    print("\n\n\n\nPANG\n\n\n\n")
     xj, xi = expand_srcdst(g, x)
     #hj, hi = expand_srcdst(g, h) not needed since its invariant node features
     

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -803,9 +803,9 @@ end
 
 function (l::SAGEConv)(g::AbstractGNNGraph, x)
     check_num_nodes(g, x)
-    xj, _ = expand_srcdst(g, x)
+    xj, xi = expand_srcdst(g, x)
     m = propagate(copy_xj, g, l.aggr, xj = xj)
-    x = l.σ.(l.weight * vcat(x, m) .+ l.bias)
+    x = l.σ.(l.weight * vcat(xi, m) .+ l.bias)
     return x
 end
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -801,9 +801,10 @@ function SAGEConv(ch::Pair{Int, Int}, σ = identity; aggr = mean,
     SAGEConv(W, b, σ, aggr)
 end
 
-function (l::SAGEConv)(g::GNNGraph, x::AbstractMatrix)
+function (l::SAGEConv)(g::AbstractGNNGraph, x)
     check_num_nodes(g, x)
-    m = propagate(copy_xj, g, l.aggr, xj = x)
+    xj, _ = expand_srcdst(g, x)
+    m = propagate(copy_xj, g, l.aggr, xj = xj)
     x = l.σ.(l.weight * vcat(x, m) .+ l.bias)
     return x
 end

--- a/src/layers/heteroconv.jl
+++ b/src/layers/heteroconv.jl
@@ -65,6 +65,27 @@ function (hgc::HeteroGraphConv)(g::GNNHeteroGraph, x::Union{NamedTuple,Dict})
     return _reduceby_node_t(hgc.aggr, outs, dst_ntypes)
 end
 
+
+function (hgc::HeteroGraphConv)(g::GNNHeteroGraph, x::NamedTuple, h::AbstractMatrix)
+    function forw(l, et)
+        sg = edge_type_subgraph(g, et)
+        node1_t, _, node2_t = et
+
+        print(x,"\n\n", h,"before\n\n\n")
+
+        x_features = (x[node1_t], x[node2_t])
+        h_features = h # temporary
+
+        return l(sg, h_features, x_features)
+
+    end
+    outs = [forw(l, et) for (l, et) in zip(hgc.layers, hgc.etypes)]
+    dst_ntypes = [et[3] for et in hgc.etypes]
+    return _reduceby_node_t(hgc.aggr, outs, dst_ntypes)
+end
+
+
+
 function _reduceby_node_t(aggr, outs, ntypes)
     function _reduce(node_t)
         idxs = findall(x -> x == node_t, ntypes)

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -111,8 +111,8 @@
 
     @testset "SAGEConv" begin
         x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 3))
-        layers = HeteroGraphConv((:A, :to, :B) => EdgeConv(Dense(2 * 4, 2), aggr = +),
-                                 (:B, :to, :A) => EdgeConv(Dense(2 * 4, 2), aggr = +));
+        layers = HeteroGraphConv((:A, :to, :B) => SAGEConv(Dense(2 * 4, 2), relu, aggr = +),
+                                 (:B, :to, :A) => SAGEConv(Dense(2 * 4, 2), relu, aggr = +));
         y = layers(hg, x); 
         @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
     end

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -109,4 +109,12 @@
         @test size(y.A) == (2,2) && size(y.B) == (2,3)
     end
 
+    @testset "SAGEConv" begin
+        x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 3))
+        layers = HeteroGraphConv((:A, :to, :B) => SAGEConv(4 => 2, relu),
+                                 (:B, :to, :A) => SAGEConv(4 => 2, relu));
+        y = layers(hg, x); 
+        @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
+    end
+
 end

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -108,4 +108,12 @@
         y = layers(hg, x); 
         @test size(y.A) == (2,2) && size(y.B) == (2,3)
     end
+
+    @testset "SAGEConv" begin
+        x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 3))
+        layers = HeteroGraphConv((:A, :to, :B) => EdgeConv(Dense(2 * 4, 2), aggr = +),
+                                 (:B, :to, :A) => EdgeConv(Dense(2 * 4, 2), aggr = +));
+        y = layers(hg, x); 
+        @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
+    end
 end

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -108,13 +108,4 @@
         y = layers(hg, x); 
         @test size(y.A) == (2,2) && size(y.B) == (2,3)
     end
-
-    @testset "SAGEConv" begin
-        x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 3))
-        layers = HeteroGraphConv((:A, :to, :B) => SAGEConv(4 => 2, relu),
-                                 (:B, :to, :A) => SAGEConv(4 => 2, relu));
-        y = layers(hg, x); 
-        @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
-    end
-
 end

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -111,8 +111,8 @@
 
     @testset "SAGEConv" begin
         x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 3))
-        layers = HeteroGraphConv((:A, :to, :B) => SAGEConv(Dense(2 * 4, 2), relu, aggr = +),
-                                 (:B, :to, :A) => SAGEConv(Dense(2 * 4, 2), relu, aggr = +));
+        layers = HeteroGraphConv((:A, :to, :B) => SAGEConv(4 => 2, relu, bias = false, aggr = +),
+                                 (:B, :to, :A) => SAGEConv(4 => 2, relu, bias = false, aggr = +));
         y = layers(hg, x); 
         @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,27 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true # for MLDatasets
 include("test_utils.jl")
 
 tests = [
+    "GNNGraphs/chainrules",
+    "GNNGraphs/datastore",
+    "GNNGraphs/gnngraph",
+    "GNNGraphs/convert",
+    "GNNGraphs/transform",
+    "GNNGraphs/operators",
+    "GNNGraphs/generate",
+    "GNNGraphs/query",
+    "GNNGraphs/sampling",
+    "GNNGraphs/gnnheterograph",
+    "GNNGraphs/temporalsnapshotsgnngraph",
+    "utils",
+    "msgpass",
+    "layers/basic",
+    "layers/conv",
     "layers/heteroconv",
+    "layers/temporalconv",
+    "layers/pool",
+    "mldatasets",
+    "examples/node_classification_cora",
+    "deprecations",
 ]
 
 !CUDA.functional() && @warn("CUDA unavailable, not testing GPU support")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,27 +25,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true # for MLDatasets
 include("test_utils.jl")
 
 tests = [
-    "GNNGraphs/chainrules",
-    "GNNGraphs/datastore",
-    "GNNGraphs/gnngraph",
-    "GNNGraphs/convert",
-    "GNNGraphs/transform",
-    "GNNGraphs/operators",
-    "GNNGraphs/generate",
-    "GNNGraphs/query",
-    "GNNGraphs/sampling",
-    "GNNGraphs/gnnheterograph",
-    "GNNGraphs/temporalsnapshotsgnngraph",
-    "utils",
-    "msgpass",
-    "layers/basic",
-    "layers/conv",
     "layers/heteroconv",
-    "layers/temporalconv",
-    "layers/pool",
-    "mldatasets",
-    "examples/node_classification_cora",
-    "deprecations",
 ]
 
 !CUDA.functional() && @warn("CUDA unavailable, not testing GPU support")


### PR DESCRIPTION
Covers Issue #311 

This is a work in progress, just wanted to make sure I am on the right track

Since `EGNNConv` has `H` as input as well I added another function:
```
function (hgc::HeteroGraphConv)(g::GNNHeteroGraph, x::NamedTuple, h::AbstractMatrix)
    function forw(l, et)
        sg = edge_type_subgraph(g, et)
        node1_t, _, node2_t = et

        x_features = (x[node1_t], x[node2_t])
        h_features = h # temporary

        return l(sg, h_features, x_features)
    end
    outs = [forw(l, et) for (l, et) in zip(hgc.layers, hgc.etypes)]
    dst_ntypes = [et[3] for et in hgc.etypes]
    return _reduceby_node_t(hgc.aggr, outs, dst_ntypes)
end
```

Let me know if there is an alternative like using the arg in the old function (pass as a `Dict`) but this just seemed more convenient. 


Will add more updates and test in the coming days. **Will remove all debug statements when done.**