### PR TITLE
Add GINConv support to HeteroGraphConv

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -682,7 +682,7 @@ GINConv(nn, ϵ; aggr = +) = GINConv(nn, ϵ, aggr)
 
 function (l::GINConv)(g::AbstractGNNGraph, x)
     check_num_nodes(g, x)
-    xj, _ = expand_srcdst(g, x)
+    xj, _ = expand_srcdst(g, x) # hetero graphs
 
     m = propagate(copy_xj, g, l.aggr, xj = xj)
     l.nn((1 + ofeltype(x, l.ϵ)) * x + m)

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -686,11 +686,7 @@ function (l::GINConv)(g::AbstractGNNGraph, x)
  
     m = propagate(copy_xj, g, l.aggr, xj = xj)
     
-    if g isa GNNHeteroGraph
-        l.nn((1 .+ ofeltype(xi, l.ϵ)) .* xi .+ m)
-    else
-        l.nn((1 + ofeltype(x, l.ϵ)) * x + m)
-    end
+    l.nn((1 .+ ofeltype(xi, l.ϵ)) .* xi .+ m)
 end
 
 function Base.show(io::IO, l::GINConv)

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -682,10 +682,15 @@ GINConv(nn, ϵ; aggr = +) = GINConv(nn, ϵ, aggr)
 
 function (l::GINConv)(g::AbstractGNNGraph, x)
     check_num_nodes(g, x)
-    xj, _ = expand_srcdst(g, x) # hetero graphs
-
+    xj, xi = expand_srcdst(g, x) 
+ 
     m = propagate(copy_xj, g, l.aggr, xj = xj)
-    l.nn((1 + ofeltype(x, l.ϵ)) * x + m)
+    
+    if g isa GNNHeteroGraph
+        #
+    else
+        l.nn((1 + ofeltype(x, l.ϵ)) * x + m)
+    end
 end
 
 function Base.show(io::IO, l::GINConv)

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -687,7 +687,7 @@ function (l::GINConv)(g::AbstractGNNGraph, x)
     m = propagate(copy_xj, g, l.aggr, xj = xj)
     
     if g isa GNNHeteroGraph
-        #
+        l.nn((1 .+ ofeltype(xi, l.ϵ)) .* xi .+ m)
     else
         l.nn((1 + ofeltype(x, l.ϵ)) * x + m)
     end

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -680,9 +680,11 @@ Flux.trainable(l::GINConv) = (nn = l.nn,)
 
 GINConv(nn, ϵ; aggr = +) = GINConv(nn, ϵ, aggr)
 
-function (l::GINConv)(g::GNNGraph, x::AbstractMatrix)
+function (l::GINConv)(g::AbstractGNNGraph, x)
     check_num_nodes(g, x)
-    m = propagate(copy_xj, g, l.aggr, xj = x)
+    xj, _ = expand_srcdst(g, x)
+
+    m = propagate(copy_xj, g, l.aggr, xj = xj)
     l.nn((1 + ofeltype(x, l.ϵ)) * x + m)
 end
 

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -109,4 +109,14 @@
         @test size(y.A) == (2,2) && size(y.B) == (2,3)
     end
 
+    @testset "GINConv" begin
+        g = rand_bipartite_heterograph((2, 5), 10)
+        x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 5));
+        layer = HeteroGraphConv((:A, :to, :B) => GraphConv(4 => 2, relu),
+                                (:B, :to, :A) => GraphConv(4 => 2, relu)); #just temporary
+        y = layer(g, x); 
+        out = GINConv(y, 1e-5) # not sure how to use it exactly
+        # continue test
+    end
+
 end

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -117,13 +117,11 @@
         @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
     end
     @testset "GINConv" begin
-        g = rand_bipartite_heterograph((2, 5), 10)
-        x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 5));
-        layer = HeteroGraphConv((:A, :to, :B) => GraphConv(4 => 2, relu),
-                                (:B, :to, :A) => GraphConv(4 => 2, relu)); #just temporary
-        y = layer(g, x); 
-        out = GINConv(y, 1e-5) # not sure how to use it exactly
-        # continue test
+        x = (A = rand(4,2), B = rand(4, 3))
+        layers = HeteroGraphConv( (:A, :to, :B) => GINConv(Dense(2 * 4, 2), 0.4),
+                                    (:B, :to, :A) => GINConv(Dense(2 * 4, 2), 0.4));
+        y = layers(hg, x); 
+        @test size(y.A) == (2,2) && size(y.B) == (2,3)
     end
 
 end

--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -117,11 +117,10 @@
         @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
     end
     @testset "GINConv" begin
-        x = (A = rand(4,2), B = rand(4, 3))
-        layers = HeteroGraphConv( (:A, :to, :B) => GINConv(Dense(2 * 4, 2), 0.4),
-                                    (:B, :to, :A) => GINConv(Dense(2 * 4, 2), 0.4));
+        x = (A = rand(4, 2), B = rand(4, 3))
+        layers = HeteroGraphConv((:A, :to, :B) => GINConv(Dense(4, 2), 0.4),
+                                    (:B, :to, :A) => GINConv(Dense(4, 2), 0.4));
         y = layers(hg, x); 
-        @test size(y.A) == (2,2) && size(y.B) == (2,3)
+        @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
     end
-
 end


### PR DESCRIPTION
Covers Issue #311 

This operation needs to be done differently for hetero graphs
```
    if g isa GNNHeteroGraph
        #
    else
        l.nn((1 + ofeltype(x, l.ϵ)) * x + m)
    end
```

[EDIT: done]