### PR TITLE
Adapt 4 convolutions to `TemporalSnapshotsGNNGraph`s

### DIFF
--- a/docs/src/api/conv.md
+++ b/docs/src/api/conv.md
@@ -25,14 +25,14 @@ The table below lists all graph convolutional layers implemented in the *GraphNe
 | [`GATConv`](@ref)           |          |           |     ✓       |              |                            |
 | [`GATv2Conv`](@ref)         |          |           |     ✓       |              |                            |
 | [`GatedGraphConv`](@ref)    |     ✓    |           |             |              |                            |
-| [`GCNConv`](@ref)           |     ✓    |     ✓     |             |              |                            |
+| [`GCNConv`](@ref)           |     ✓    |     ✓     |             |              |               ✓            |
 | [`GINConv`](@ref)           |     ✓    |           |             |              |                ✓           |
 | [`GMMConv`](@ref)           |          |           |     ✓       |              |                            |
-| [`GraphConv`](@ref)         |     ✓    |           |             |       ✓      |                            |   
+| [`GraphConv`](@ref)         |     ✓    |           |             |       ✓      |              ✓              |   
 | [`MEGNetConv`](@ref)        |          |           |     ✓       |              |                            |              
 | [`NNConv`](@ref)            |          |           |     ✓       |              |                            |
-| [`ResGatedGraphConv`](@ref) |          |           |             |              |                            |
-| [`SAGEConv`](@ref)          |     ✓    |           |             |              |                           |
+| [`ResGatedGraphConv`](@ref) |          |           |             |              |               ✓             |
+| [`SAGEConv`](@ref)          |     ✓    |           |             |              |             ✓               |
 | [`SGConv`](@ref)            |     ✓    |           |             |              |                           |
 | [`TransformerConv`](@ref)   |          |           |     ✓       |              |                           |
 

--- a/src/layers/temporalconv.jl
+++ b/src/layers/temporalconv.jl
@@ -190,3 +190,19 @@ end
 function (l::GINConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
     return l.(tg.snapshots, x)
 end
+
+function (l::GCNConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::ResGatedGraphConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::SAGEConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::GraphConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end

--- a/test/layers/temporalconv.jl
+++ b/test/layers/temporalconv.jl
@@ -40,3 +40,31 @@ end
     @test size(ginconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
     @test length(Flux.gradient(x ->sum(sum(ginconv(tg, x))), tg.ndata.x)[1]) == S    
 end
+
+@testset "GCNConv" begin
+    gcnconv = GCNConv(in_channel => out_channel)
+    @test length(gcnconv(tg, tg.ndata.x)) == S
+    @test size(gcnconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(gcnconv(tg, x))), tg.ndata.x)[1]) == S    
+end
+
+@testset "ResGatedGraphConv" begin
+    resgatedconv = ResGatedGraphConv(in_channel => out_channel, relu)
+    @test length(resgatedconv(tg, tg.ndata.x)) == S
+    @test size(resgatedconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(resgatedconv(tg, x))), tg.ndata.x)[1]) == S    
+end
+
+@testset "SAGEConv" begin 
+    sageconv = SAGEConv(in_channel => out_channel)
+    @test length(sageconv(tg, tg.ndata.x)) == S
+    @test size(sageconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(sageconv(tg, x))), tg.ndata.x)[1]) == S    
+end
+
+@testset "GraphConv" begin
+    graphconv = GraphConv(in_channel => out_channel,relu)
+    @test length(graphconv(tg, tg.ndata.x)) == S
+    @test size(graphconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(graphconv(tg, x))), tg.ndata.x)[1]) == S    
+end


### PR DESCRIPTION
This PR adapts `GCNConv`, `ResGatedGraphConv`, `SAGEConv` and `GraphConv` to the temporal case. They are applied to each snapshot independently.