### PR TITLE
Add more conv layers with TemporalSnapshotsGNNGraphs support

### DIFF
--- a/docs/src/api/conv.md
+++ b/docs/src/api/conv.md
@@ -18,13 +18,13 @@ The table below lists all graph convolutional layers implemented in the *GraphNe
 | Layer                       |Sparse Ops|Edge Weight|Edge Features| Heterograph  | TemporalSnapshotsGNNGraphs |
 | :--------                   |  :---:   |:---:      |:---:        |  :---:       | :---:                      |
 | [`AGNNConv`](@ref)          |          |           |     ✓       |              |                    |                          
-| [`CGConv`](@ref)            |          |           |     ✓       |              |                           | 
-| [`ChebConv`](@ref)          |          |           |             |              |                            |
+| [`CGConv`](@ref)            |          |           |     ✓       |              |             ✓             | 
+| [`ChebConv`](@ref)          |          |           |             |              |                ✓           |
 | [`EGNNConv`](@ref)          |          |           |     ✓       |              |                           |
 | [`EdgeConv`](@ref)          |          |           |             |              |                            |  
-| [`GATConv`](@ref)           |          |           |     ✓       |              |                            |
-| [`GATv2Conv`](@ref)         |          |           |     ✓       |              |                            |
-| [`GatedGraphConv`](@ref)    |     ✓    |           |             |              |                            |
+| [`GATConv`](@ref)           |          |           |     ✓       |              |              ✓             |
+| [`GATv2Conv`](@ref)         |          |           |     ✓       |              |             ✓              |
+| [`GatedGraphConv`](@ref)    |     ✓    |           |             |              |            ✓               |
 | [`GCNConv`](@ref)           |     ✓    |     ✓     |             |              |                            |
 | [`GINConv`](@ref)           |     ✓    |           |             |              |                ✓           |
 | [`GMMConv`](@ref)           |          |           |     ✓       |              |                            |
@@ -33,7 +33,7 @@ The table below lists all graph convolutional layers implemented in the *GraphNe
 | [`NNConv`](@ref)            |          |           |     ✓       |              |                            |
 | [`ResGatedGraphConv`](@ref) |          |           |             |              |                            |
 | [`SAGEConv`](@ref)          |     ✓    |           |             |              |                           |
-| [`SGConv`](@ref)            |     ✓    |           |             |              |                           |
+| [`SGConv`](@ref)            |     ✓    |           |             |              |              ✓            |
 | [`TransformerConv`](@ref)   |          |           |     ✓       |              |                           |
 
 

--- a/src/layers/temporalconv.jl
+++ b/src/layers/temporalconv.jl
@@ -190,3 +190,35 @@ end
 function (l::GINConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
     return l.(tg.snapshots, x)
 end
+
+function (l::ChebConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::GATConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::GATv2Conv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::GatedGraphConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::GINConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::CGConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::SGConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end
+
+function (l::TransformerConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
+    return l.(tg.snapshots, x)
+end

--- a/test/layers/temporalconv.jl
+++ b/test/layers/temporalconv.jl
@@ -40,3 +40,52 @@ end
     @test size(ginconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
     @test length(Flux.gradient(x ->sum(sum(ginconv(tg, x))), tg.ndata.x)[1]) == S    
 end
+
+@testset "ChebConv" begin
+    chebconv = ChebConv(in_channel => out_channel, 5)
+    @test length(chebconv(tg, tg.ndata.x)) == S
+    @test size(chebconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(chebconv(tg, x))), tg.ndata.x)[1]) == S
+end
+
+@testset "GATConv" begin
+    gatconv = GATConv(in_channel => out_channel)
+    @test length(gatconv(tg, tg.ndata.x)) == S
+    @test size(gatconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(gatconv(tg, x))), tg.ndata.x)[1]) == S
+end
+
+@testset "GATv2Conv" begin
+    gatv2conv = GATv2Conv(in_channel => out_channel)
+    @test length(gatv2conv(tg, tg.ndata.x)) == S
+    @test size(gatv2conv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(gatv2conv(tg, x))), tg.ndata.x)[1]) == S
+end
+
+@testset "GatedGraphConv" begin
+    gatedgraphconv = GatedGraphConv(5, 5)
+    @test length(gatedgraphconv(tg, tg.ndata.x)) == S
+    @test size(gatedgraphconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(gatedgraphconv(tg, x))), tg.ndata.x)[1]) == S
+end
+
+@testset "CGConv" begin
+    cgconv = CGConv(in_channel => out_channel)
+    @test length(cgconv(tg, tg.ndata.x)) == S
+    @test size(cgconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(cgconv(tg, x))), tg.ndata.x)[1]) == S
+end
+
+@testset "SGConv" begin
+    sgconv = SGConv(in_channel => out_channel)
+    @test length(sgconv(tg, tg.ndata.x)) == S
+    @test size(sgconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(sgconv(tg, x))), tg.ndata.x)[1]) == S
+end
+
+@testset "TransformerConv" begin
+    transformerconv = TransformerConv(in_channel => out_channel)
+    @test length(transformerconv(tg, tg.ndata.x)) == S
+    @test size(transformerconv(tg, tg.ndata.x)[1]) == (out_channel, N) 
+    @test length(Flux.gradient(x ->sum(sum(transformerconv(tg, x))), tg.ndata.x)[1]) == S
+end


### PR DESCRIPTION
This is meant to be a continuation of PR #392 applying conv to all the temporal snapshots independently 
**Once PR #392 gets merged I'll fix the merge conflicts and this will be ready for merge as well**

This PR adds the following layers:

- ChebConv
- GATConv
- GATv2Conv
- GatedGraphConv
- CGConv
- SGConv
- TransformerConv

