### PR TITLE
Remove duplicate of `GINConv` for `TemporalSnapshotsGNNGraph`

### DIFF
--- a/src/layers/temporalconv.jl
+++ b/src/layers/temporalconv.jl
@@ -207,10 +207,6 @@ function (l::GatedGraphConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
     return l.(tg.snapshots, x)
 end
 
-function (l::GINConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
-    return l.(tg.snapshots, x)
-end
-
 function (l::CGConv)(tg::TemporalSnapshotsGNNGraph, x::AbstractVector)
     return l.(tg.snapshots, x)
 end


### PR DESCRIPTION
It would take a new release to fully fix issue #406.