### PR TITLE
fix: SGConv layer fixes after implementing support for GNNHeteroGraph

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using Zygote
 using Test
 using MLDatasets
 using InlineStrings  # not used but with the import we test #98 and #104
+using SimpleWeightedGraphs
 
 CUDA.allowscalar(false)
 
@@ -46,6 +47,7 @@ tests = [
     "mldatasets",
     "examples/node_classification_cora",
     "deprecations",
+    "ext/GraphNeuralNetworksSimpleWeightedGraphsExt/GraphNeuralNetworksSimpleWeightedGraphsExt"
 ]
 
 !CUDA.functional() && @warn("CUDA unavailable, not testing GPU support")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,6 @@ using Zygote
 using Test
 using MLDatasets
 using InlineStrings  # not used but with the import we test #98 and #104
-using SimpleWeightedGraphs
 
 CUDA.allowscalar(false)
 
@@ -47,7 +46,6 @@ tests = [
     "mldatasets",
     "examples/node_classification_cora",
     "deprecations",
-    "ext/GraphNeuralNetworksSimpleWeightedGraphsExt/GraphNeuralNetworksSimpleWeightedGraphsExt"
 ]
 
 !CUDA.functional() && @warn("CUDA unavailable, not testing GPU support")


### PR DESCRIPTION
This PR introduces some optimizations and fixes for SGConv.

Fix: 
- previously the loop for propagation involved `x = x .* c'` and it was the only place where `x` was referred to after expansion to `xi` and `xj`. in the propagation process `xj` was passed which made this line of code unnecessary and potentially problematic (remember that for GNNHeteroGraph `x` contains both `xi` and `xj`)

Optimizations:
- reduces number of ifs as definition for `edge_t` not necessary anymore (after changing `add_self_loop` behavior it was used only once in `degree`)
- introduces optimization for multiplying weights before convolution if `Dout < Din` (but only when `g` is not `GNNHeteroGraph`
