### PR TITLE
fix: remove SGConv GNNHeteroGraph support

### DIFF
--- a/test/layers/heteroconv.jl
+++ b/test/layers/heteroconv.jl
@@ -109,14 +109,6 @@
         @test size(y.A) == (2,2) && size(y.B) == (2,3)
     end
   
-    @testset "SGConv" begin
-        x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 3))
-        layers = HeteroGraphConv((:A, :to, :B) => SGConv(4 => 2),
-                                 (:B, :to, :A) => SGConv(4 => 2));
-        y = layers(hg, x); 
-        @test size(y.A) == (2, 2) && size(y.B) == (2, 3)
-    end
-  
     @testset "SAGEConv" begin
         x = (A = rand(Float32, 4, 2), B = rand(Float32, 4, 3))
         layers = HeteroGraphConv((:A, :to, :B) => SAGEConv(4 => 2, relu, bias = false, aggr = +),


### PR DESCRIPTION
This PR removes GNNHeteroGraph support for SGConv layer as per discussion here https://github.com/CarloLucibello/GraphNeuralNetworks.jl/pull/415

This is due to the fact that looping mechanism makes SGConv layer not stable enough for GNNHeteroGraph support.