### PR TITLE
chore: Update docs for HeteroGNN support

### DIFF
--- a/docs/src/api/conv.md
+++ b/docs/src/api/conv.md
@@ -25,7 +25,7 @@ The table below lists all graph convolutional layers implemented in the *GraphNe
 | [`GATConv`](@ref)           |          |           |     ✓       |       ✓      |              ✓             |
 | [`GATv2Conv`](@ref)         |          |           |     ✓       |       ✓      |             ✓              |
 | [`GatedGraphConv`](@ref)    |     ✓    |           |             |              |            ✓               |
-| [`GCNConv`](@ref)           |     ✓    |     ✓     |             |              |                            |
+| [`GCNConv`](@ref)           |     ✓    |     ✓     |             |       ✓      |                            |
 | [`GINConv`](@ref)           |     ✓    |           |             |       ✓      |               ✓           |
 | [`GMMConv`](@ref)           |          |           |     ✓       |              |                            |
 | [`GraphConv`](@ref)         |     ✓    |           |             |       ✓      |              ✓             |   
@@ -33,7 +33,7 @@ The table below lists all graph convolutional layers implemented in the *GraphNe
 | [`NNConv`](@ref)            |          |           |     ✓       |              |                            |
 | [`ResGatedGraphConv`](@ref) |          |           |             |       ✓      |               ✓             |
 | [`SAGEConv`](@ref)          |     ✓    |           |             |       ✓      |             ✓               |
-| [`SGConv`](@ref)            |     ✓    |           |             |       ✓      |             ✓             |
+| [`SGConv`](@ref)            |     ✓    |           |             |              |             ✓             |
 | [`TransformerConv`](@ref)   |          |           |     ✓       |              |                           |
 
 


### PR DESCRIPTION
This PR updates docs for HeteroGNN support to account for new layers, as well as removing `SGConv` as per PR #416 .