### PR TITLE
Added Personalized PageRank Diffusion [`ppr_diffusion` function]

### DIFF
--- a/src/GNNGraphs/GNNGraphs.jl
+++ b/src/GNNGraphs/GNNGraphs.jl
@@ -78,6 +78,7 @@ export add_nodes,
        to_unidirected,
        random_walk_pe,
        remove_nodes,
+       ppr_diffusion,
 # from Flux
        batch,
        unbatch,

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1098,7 +1098,7 @@ The function performs the following steps:
 # Returns
 - A new `GNNGraph` instance with the same structure as `g` but with updated edge weights according to the PPR diffusion calculation.
 """
-function ppr_diffusion(g::GNNGraph{<:COO_T}; alpha_f32::Float32=0.85f0)
+function ppr_diffusion(g::GNNGraph{<:COO_T}; alpha = 0.85f0)
     s, t = edge_index(g)
     w = ones(Float32, g.num_edges)
 

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1079,7 +1079,7 @@ ci2t(ci::AbstractVector{<:CartesianIndex}, dims) = ntuple(i -> map(x -> x[i], ci
 @non_differentiable dense_zeros_like(x...)
 
 """
-    ppr_diffusion(g::GNNGraph{<:COO_T}; alpha_f32::Float32=0.85f0) -> GNNGraph
+    ppr_diffusion(g::GNNGraph{<:COO_T}, alpha =0.85f0) -> GNNGraph
 
 Calculates the Personalized PageRank (PPR) diffusion based on the edge weight matrix of a GNNGraph and updates the graph with new edge weights derived from the PPR matrix.
 References paper: [The pagerank citation ranking: Bringing order to the web](http://ilpubs.stanford.edu:8090/422)

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1105,7 +1105,7 @@ function ppr_diffusion(g::GNNGraph{<:COO_T}; alpha = 0.85f0)
     N = g.num_nodes
 
     initial_A = sparse(t, s, w, N, N)
-    scaled_A = (alpha_f32 - 1) * initial_A
+    scaled_A = (Float32(alpha) - 1) * initial_A
 
     I_sparse = sparse(Diagonal(ones(Float32, N)))
     A_sparse = I_sparse + scaled_A

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1190,7 +1190,10 @@ The function performs the following steps:
 """
 function ppr_diffusion(g::GNNGraph{<:COO_T}; alpha = 0.85f0)
     s, t = edge_index(g)
-    w = ones(Float32, g.num_edges)
+    w = get_edge_weight(g)
+    if isnothing(w)
+        w = ones(Float32, g.num_edges)
+    end
 
     N = g.num_nodes
 

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1081,7 +1081,8 @@ ci2t(ci::AbstractVector{<:CartesianIndex}, dims) = ntuple(i -> map(x -> x[i], ci
 """
     ppr_diffusion(g::GNNGraph{<:COO_T}; alpha_f32::Float32=0.85f0) -> GNNGraph
 
-Calculates the Personalized PageRank (PPR) diffusion based on the edge weight matrix of a GNNGraph and updates the graph with new edge weights derived from the PPR matrix as introduced in the paper [The pagerank citation ranking: Bringing order to the web](http://ilpubs.stanford.edu:8090/422)
+Calculates the Personalized PageRank (PPR) diffusion based on the edge weight matrix of a GNNGraph and updates the graph with new edge weights derived from the PPR matrix.
+References paper: [The pagerank citation ranking: Bringing order to the web](http://ilpubs.stanford.edu:8090/422)
 
 
 The function performs the following steps:

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1079,7 +1079,7 @@ ci2t(ci::AbstractVector{<:CartesianIndex}, dims) = ntuple(i -> map(x -> x[i], ci
 @non_differentiable dense_zeros_like(x...)
 
 """
-    ppr_diffusion(g::GNNGraph; alpha_f32::Float32=0.85f0) -> GNNGraph
+    ppr_diffusion(g::GNNGraph{<:COO_T}; alpha_f32::Float32=0.85f0) -> GNNGraph
 
 Calculates the Personalized PageRank (PPR) diffusion based on the edge weight matrix of a GNNGraph and updates the graph with new edge weights derived from the PPR matrix.
 
@@ -1096,7 +1096,7 @@ The function performs the following steps:
 # Returns
 - A new `GNNGraph` instance with the same structure as `g` but with updated edge weights according to the PPR diffusion calculation.
 """
-function ppr_diffusion(g::GNNGraph; alpha_f32::Float32=0.85f0)
+function ppr_diffusion(g::GNNGraph{<:COO_T}; alpha_f32::Float32=0.85f0)
     s, t = edge_index(g)
     w = get_edge_weight(g)  
 

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1081,7 +1081,8 @@ ci2t(ci::AbstractVector{<:CartesianIndex}, dims) = ntuple(i -> map(x -> x[i], ci
 """
     ppr_diffusion(g::GNNGraph{<:COO_T}; alpha_f32::Float32=0.85f0) -> GNNGraph
 
-Calculates the Personalized PageRank (PPR) diffusion based on the edge weight matrix of a GNNGraph and updates the graph with new edge weights derived from the PPR matrix.
+Calculates the Personalized PageRank (PPR) diffusion based on the edge weight matrix of a GNNGraph and updates the graph with new edge weights derived from the PPR matrix as introduced in the paper [The pagerank citation ranking: Bringing order to the web](http://ilpubs.stanford.edu:8090/422)
+
 
 The function performs the following steps:
 1. Constructs a modified adjacency matrix `A` using the graph's edge weights, where `A` is adjusted by `(α - 1) * A + I`, with `α` being the damping factor (`alpha_f32`) and `I` the identity matrix.

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1205,7 +1205,7 @@ function ppr_diffusion(g::GNNGraph{<:COO_T}; alpha = 0.85f0)
 
     A_dense = Matrix(A_sparse)
 
-    PPR = alpha_f32 * inv(A_dense)
+    PPR = alpha * inv(A_dense)
 
     new_w = [PPR[dst, src] for (src, dst) in zip(s, t)]
 

--- a/src/GNNGraphs/transform.jl
+++ b/src/GNNGraphs/transform.jl
@@ -1078,3 +1078,53 @@ ci2t(ci::AbstractVector{<:CartesianIndex}, dims) = ntuple(i -> map(x -> x[i], ci
 @non_differentiable remove_self_loops(x...)  # TODO this is wrong, since g carries feature arrays, needs rrule
 @non_differentiable dense_zeros_like(x...)
 
+"""
+    ppr_diffusion(g::GNNGraph; alpha_f32::Float32=0.85f0) -> GNNGraph
+
+Calculates the Personalized PageRank (PPR) diffusion based on the edge weight matrix of a GNNGraph and updates the graph with new edge weights derived from the PPR matrix.
+
+The function performs the following steps:
+1. Constructs a modified adjacency matrix `A` using the graph's edge weights, where `A` is adjusted by `(α - 1) * A + I`, with `α` being the damping factor (`alpha_f32`) and `I` the identity matrix.
+2. Normalizes `A` to ensure each column sums to 1, representing transition probabilities.
+3. Applies the PPR formula `α * (I + (α - 1) * A)^-1` to compute the diffusion matrix.
+4. Updates the original edge weights of the graph based on the PPR diffusion matrix, assigning new weights for each edge from the PPR matrix.
+
+# Arguments
+- `g::GNNGraph`: The input graph for which PPR diffusion is to be calculated. It should have edge weights available.
+- `alpha_f32::Float32`: The damping factor used in PPR calculation, controlling the teleport probability in the random walk. Defaults to `0.85f0`.
+
+# Returns
+- A new `GNNGraph` instance with the same structure as `g` but with updated edge weights according to the PPR diffusion calculation.
+"""
+function ppr_diffusion(g::GNNGraph; alpha_f32::Float32=0.85f0)
+    s, t = edge_index(g)
+    w = get_edge_weight(g)  
+
+    N = g.num_nodes
+
+    A = zeros(Float32, N, N)
+    
+    for (idx, src, dst) in zip(1:length(s), s, t)
+        A[dst, src] += w[idx]  
+    end
+
+    A .*= (alpha_f32 - 1)
+
+    for i in 1:N
+        A[i, i] += 1
+    end
+
+    # α * (I + (α - 1) * A)^-1
+    PPR = alpha_f32 * inv(A)
+    println(PPR)
+
+    new_w = Float32[]
+    for (src, dst) in zip(s, t)
+        push!(new_w, PPR[dst, src]) 
+    end
+
+    return GNNGraph((s, t, new_w),
+                    g.num_nodes, length(s), g.num_graphs,
+                    g.graph_indicator,
+                    g.ndata, g.edata, g.gdata)
+end

--- a/test/GNNGraphs/transform.jl
+++ b/test/GNNGraphs/transform.jl
@@ -613,6 +613,6 @@ end
                            0.038249996
                            0.050999995]
 
-        isapprox(w_new, check_ew)
+        @test w_new ≈ check_ew
     end
 end

--- a/test/GNNGraphs/transform.jl
+++ b/test/GNNGraphs/transform.jl
@@ -528,7 +528,6 @@ end
         eweights = [0.1, 0.2, 0.3, 0.4]
 
         g = GNNGraph(s, t, eweights)
-        get_edge_weight(g)
 
         g_new = ppr_diffusion(g)
         w_new = get_edge_weight(g_new)

--- a/test/GNNGraphs/transform.jl
+++ b/test/GNNGraphs/transform.jl
@@ -613,6 +613,6 @@ end
                            0.038249996
                            0.050999995]
 
-        isequal(w_new, check_ew)
+        isapprox(w_new, check_ew)
     end
 end

--- a/test/GNNGraphs/transform.jl
+++ b/test/GNNGraphs/transform.jl
@@ -527,7 +527,7 @@ end
         t = [2, 3, 4, 5]
         eweights = [0.1, 0.2, 0.3, 0.4]
 
-        g = GNNGraph(s,t,eweights)
+        g = GNNGraph(s, t, eweights)
         get_edge_weight(g)
 
         g_new = ppr_diffusion(g)

--- a/test/GNNGraphs/transform.jl
+++ b/test/GNNGraphs/transform.jl
@@ -609,9 +609,9 @@ end
         w_new = get_edge_weight(g_new)
 
         check_ew = Float32[0.012749999
-        0.025499998
-        0.038249996
-        0.050999995]
+                           0.025499998
+                           0.038249996
+                           0.050999995]
 
         isequal(w_new, check_ew)
     end

--- a/test/GNNGraphs/transform.jl
+++ b/test/GNNGraphs/transform.jl
@@ -520,3 +520,24 @@ end
         @test g.graph[(:A, :to1, :A)][3] == vcat([2, 2, 2], fill(1, n))
     end
 end
+
+@testset "ppr_diffusion" begin
+    if GRAPH_T == :coo
+        s = [1, 1, 2, 3]
+        t = [2, 3, 4, 5]
+        eweights = [0.1, 0.2, 0.3, 0.4]
+
+        g = GNNGraph(s,t,eweights)
+        get_edge_weight(g)
+
+        g_new = ppr_diffusion(g)
+        w_new = get_edge_weight(g_new)
+
+        check_ew = Float32[0.012749999
+        0.025499998
+        0.038249996
+        0.050999995]
+
+        isequal(w_new, check_ew)
+    end
+end


### PR DESCRIPTION
Continues Issue #412, takes inspiration from [DGL implementation](https://docs.dgl.ai/en/0.8.x/generated/dgl.transforms.PPR.html)

This PR introduces a new function, `ppr_diffusion`. It calculates Personalized PageRank (PPR) diffusion based on the edge weight matrix and updates the graph with new edge weights derived from the PPR matrix.

Implementation:

The function operates in several key steps:

- Construct Modified Adjacency Matrix (A): Utilizes existing edge weights (w) to build a matrix $A$ representing the graph's structure, adjusted by $(α - 1)$, where $α$ is the damping factor. This adjustment incorporates both direct connections and global graph structure.

```julia

A[dst, src] += w[idx]
A .*= (alpha_f32 - 1)
```
- Incorporate Identity Matrix (I): Adds the identity matrix to A to account for self-transitions, forming $I + (α - 1) \times A$.

```julia

A[i, i] += 1
```
- Apply PPR Formula: Calculates the PPR diffusion matrix as $α \times (I + (α - 1) \times A)^{-1}$, which effectively models the probability of transitioning from one node to another, considering random jumps governed by α.

```julia

PPR = alpha_f32 * inv(A)
```
- Update Edge Weights: Assigns new weights to each edge based on the corresponding values in the PPR matrix, effectively updating the graph's edge weights to reflect the calculated PPR diffusion.

```julia

new_w = [PPR[dst, src] for (src, dst) in zip(s, t)]
```