### PR TITLE
Add `GCNConvFixedW` layer

### DIFF
--- a/src/GraphNeuralNetworks.jl
+++ b/src/GraphNeuralNetworks.jl
@@ -57,6 +57,7 @@ export
       GATv2Conv,
       GatedGraphConv,
       GCNConv,
+      GCNConvFixedW,
       GINConv,
       GMMConv,
       GraphConv,

--- a/src/GraphNeuralNetworks.jl
+++ b/src/GraphNeuralNetworks.jl
@@ -57,7 +57,6 @@ export
       GATv2Conv,
       GatedGraphConv,
       GCNConv,
-      GCNConvFixedW,
       GINConv,
       GMMConv,
       GraphConv,

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -168,6 +168,7 @@ function Base.show(io::IO, l::GCNConv)
     print(io, ")")
 end
 
+# same architecture as GCNConv but passing the weights
 struct GCNConvFixedW{F} <: GNNLayer
     in::Int
     out::Int

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -66,6 +66,16 @@ test_graphs = [g1, g_single_vertex]
     end
 end
 
+@testset "GCNConvFixedW" begin
+    l = GraphNeuralNetworks.GCNConvFixedW(in_channel => out_channel)
+    w = zeros(T, out_channel, in_channel)
+    g1 = GNNGraph(adj1, ndata = ones(T, in_channel, N))
+    @test l(g1, g1.ndata.x, w) == zeros(T, out_channel, N)
+    a = rand(T, in_channel, N)
+    g2 = GNNGraph(adj1, ndata = a)
+    @test l(g2, g2.ndata.x, w) == w * a
+end
+
 @testset "ChebConv" begin
     k = 2
     l = ChebConv(in_channel => out_channel, k)


### PR DESCRIPTION
This PR adds the version of `GCNConv` layer in which you have to pass the weights. 
It will be part of the temporal convolution EvolveGCN of the paper https://arxiv.org/abs/1902.10191.