### PR TITLE
feat: add induced_subgraph functionality

### DIFF
--- a/GNNGraphs/src/GNNGraphs.jl
+++ b/GNNGraphs/src/GNNGraphs.jl
@@ -96,7 +96,7 @@ export rand_graph,
        rand_temporal_hyperbolic_graph
 
 include("sampling.jl")
-export sample_neighbors, induced_subgraph
+export sample_neighbors
 
 include("operators.jl")
 # Base.intersect

--- a/GNNGraphs/src/GNNGraphs.jl
+++ b/GNNGraphs/src/GNNGraphs.jl
@@ -96,7 +96,7 @@ export rand_graph,
        rand_temporal_hyperbolic_graph
 
 include("sampling.jl")
-export sample_neighbors, Graphs.induced_subgraph
+export sample_neighbors, induced_subgraph
 
 include("operators.jl")
 # Base.intersect

--- a/GNNGraphs/src/GNNGraphs.jl
+++ b/GNNGraphs/src/GNNGraphs.jl
@@ -96,8 +96,7 @@ export rand_graph,
        rand_temporal_hyperbolic_graph
 
 include("sampling.jl")
-export sample_neighbors
-export induced_subgraph
+export sample_neighbors, induced_subgraph
 
 include("operators.jl")
 # Base.intersect

--- a/GNNGraphs/src/GNNGraphs.jl
+++ b/GNNGraphs/src/GNNGraphs.jl
@@ -97,6 +97,7 @@ export rand_graph,
 
 include("sampling.jl")
 export sample_neighbors
+export induced_subgraph
 
 include("operators.jl")
 # Base.intersect

--- a/GNNGraphs/src/GNNGraphs.jl
+++ b/GNNGraphs/src/GNNGraphs.jl
@@ -96,7 +96,7 @@ export rand_graph,
        rand_temporal_hyperbolic_graph
 
 include("sampling.jl")
-export sample_neighbors, induced_subgraph
+export sample_neighbors, Graphs.induced_subgraph
 
 include("operators.jl")
 # Base.intersect

--- a/GNNGraphs/src/GNNGraphs.jl
+++ b/GNNGraphs/src/GNNGraphs.jl
@@ -4,7 +4,7 @@ using SparseArrays
 using Functors: @functor
 import Graphs
 using Graphs: AbstractGraph, outneighbors, inneighbors, adjacency_matrix, degree, 
-              has_self_loops, is_directed
+              has_self_loops, is_directed, induced_subgraph
 import NearestNeighbors
 import NNlib
 import StatsBase

--- a/GNNGraphs/src/sampling.jl
+++ b/GNNGraphs/src/sampling.jl
@@ -149,8 +149,8 @@ function Graphs.induced_subgraph(graph::GNNGraph, nodes::Vector{Int})
         end
         for neighbor in neighbors
             if neighbor in keys(node_map)
-                push!(source, node_map[node])
-                push!(target, node_map[neighbor])
+                push!(target, node_map[node])
+                push!(source, node_map[neighbor])
             end
         end
     end

--- a/GNNGraphs/src/sampling.jl
+++ b/GNNGraphs/src/sampling.jl
@@ -121,8 +121,8 @@ end
     induced_subgraph(graph::GNNGraph, nodes::Vector{Int}) -> GNNGraph
 
 Generates a subgraph from the original graph using the provided `nodes`. 
-    The function includes the nodes' neighbors and creates edges between nodes that are connected in the original graph. 
-    If a node has no neighbors, an isolated node will be added to the subgraph.
+The function includes the nodes' neighbors and creates edges between nodes that are connected in the original graph. 
+If a node has no neighbors, an isolated node will be added to the subgraph.
 
 # Arguments:
 - `graph::GNNGraph`: The original graph containing nodes, edges, and node features.

--- a/GNNGraphs/src/sampling.jl
+++ b/GNNGraphs/src/sampling.jl
@@ -163,6 +163,6 @@ function Graphs.induced_subgraph(graph::GNNGraph, nodes::Vector{Int})
         return backup_gnn  # Return empty graph if no nodes are provided
     end
 
-    return GNNGraph(source, target)
+    return GNNGraph(source, target, num_nodes = length(node_map))
     #, ndata = new_features)  # Return the new GNNGraph with subgraph and features
 end

--- a/GNNGraphs/src/sampling.jl
+++ b/GNNGraphs/src/sampling.jl
@@ -141,28 +141,23 @@ function Graphs.induced_subgraph(graph::GNNGraph, nodes::Vector{Int})
     # Collect edges to add
     source = Int[]
     target = Int[]
-    backup_gnn = GNNGraph()
+    eindices = Int[]
     for node in nodes
         neighbors = Graphs.neighbors(graph, node, dir = :in)
-        if isempty(neighbors)
-            backup_gnn = add_nodes(backup_gnn, 1)
-        end
         for neighbor in neighbors
             if neighbor in keys(node_map)
                 push!(target, node_map[node])
                 push!(source, node_map[neighbor])
+
+                eindex = findfirst(x -> x == [neighbor, node], edge_index(graph))
+                push!(eindices, eindex)
             end
         end
     end
 
     # Extract features for the new nodes
-    #new_features = graph.x[:, nodes]
+    new_ndata = getobs(graph.ndata, nodes)
+    new_edata = getobs(graph.edata, eindices)
 
-    if isempty(source) && isempty(target)
-        #backup_gnn.ndata.x = new_features ### TODO fix & add edges data (probably push themto the new vector?)
-        return backup_gnn  # Return empty graph if no nodes are provided
-    end
-
-    return GNNGraph(source, target, num_nodes = length(node_map))
-    #, ndata = new_features)  # Return the new GNNGraph with subgraph and features
+    return GNNGraph(source, target, num_nodes = length(node_map), ndata = new_ndata, edata = new_edata) 
 end

--- a/GNNGraphs/src/sampling.jl
+++ b/GNNGraphs/src/sampling.jl
@@ -118,7 +118,7 @@ function sample_neighbors(g::GNNGraph{<:COO_T}, nodes, K = -1;
 end
 
 """
-    Graphs.induced_subgraph(graph::GNNGraph, nodes::Vector{Int}) -> GNNGraph
+    induced_subgraph(graph::GNNGraph, nodes::Vector{Int}) -> GNNGraph
 
 Generates a subgraph from the original graph using the provided `nodes`. 
 The function includes the nodes' neighbors and creates edges between nodes that are connected in the original graph. 

--- a/GNNGraphs/src/sampling.jl
+++ b/GNNGraphs/src/sampling.jl
@@ -117,8 +117,9 @@ function sample_neighbors(g::GNNGraph{<:COO_T}, nodes, K = -1;
     return gnew
 end
 
+
 """
-    induced_subgraph(graph::GNNGraph, nodes::Vector{Int})
+    induced_subgraph(graph, nodes)
 
 Generates a subgraph from the original graph using the provided `nodes`. 
 The function includes the nodes' neighbors and creates edges between nodes that are connected in the original graph. 
@@ -127,12 +128,12 @@ Returns A new `GNNGraph` containing the subgraph with the specified nodes and th
 
 # Arguments
 
-- `graph::GNNGraph`. The original graph containing nodes, edges, and node features.
-- `nodes::Vector{Int}. A vector of node indices to include in the subgraph.
-
+- `graph`. The original GNNGraph containing nodes, edges, and node features.
+- `nodes``. A vector of node indices to include in the subgraph.
+     
 # Examples
 
-```jldoctest
+```julia
 julia> s = [1, 2]
 2-element Vector{Int64}:
  1
@@ -167,6 +168,7 @@ GNNGraph:
         x = 32×2 Matrix{Float32}
   edata:
         e = 1-element Vector{Float32}
+```
 """
 function Graphs.induced_subgraph(graph::GNNGraph, nodes::Vector{Int})
     if isempty(nodes)

--- a/GNNGraphs/src/sampling.jl
+++ b/GNNGraphs/src/sampling.jl
@@ -118,7 +118,7 @@ function sample_neighbors(g::GNNGraph{<:COO_T}, nodes, K = -1;
 end
 
 """
-    induced_subgraph(graph::GNNGraph, nodes::Vector{Int}) -> GNNGraph
+    Graphs.induced_subgraph(graph::GNNGraph, nodes::Vector{Int}) -> GNNGraph
 
 Generates a subgraph from the original graph using the provided `nodes`. 
 The function includes the nodes' neighbors and creates edges between nodes that are connected in the original graph. 

--- a/GNNGraphs/src/sampling.jl
+++ b/GNNGraphs/src/sampling.jl
@@ -118,18 +118,55 @@ function sample_neighbors(g::GNNGraph{<:COO_T}, nodes, K = -1;
 end
 
 """
-    induced_subgraph(graph::GNNGraph, nodes::Vector{Int}) -> GNNGraph
+    induced_subgraph(graph::GNNGraph, nodes::Vector{Int})
 
 Generates a subgraph from the original graph using the provided `nodes`. 
 The function includes the nodes' neighbors and creates edges between nodes that are connected in the original graph. 
-If a node has no neighbors, an isolated node will be added to the subgraph.
+If a node has no neighbors, an isolated node will be added to the subgraph. 
+Returns A new `GNNGraph` containing the subgraph with the specified nodes and their features.
 
-# Arguments:
-- `graph::GNNGraph`: The original graph containing nodes, edges, and node features.
-- `nodes::Vector{Int}`: A vector of node indices to include in the subgraph.
+# Arguments
 
-# Returns:
-A new `GNNGraph` containing the subgraph with the specified nodes and their features.
+- `graph::GNNGraph`. The original graph containing nodes, edges, and node features.
+- `nodes::Vector{Int}. A vector of node indices to include in the subgraph.
+
+# Examples
+
+```jldoctest
+julia> s = [1, 2]
+2-element Vector{Int64}:
+ 1
+ 2
+
+julia> t = [2, 3]
+2-element Vector{Int64}:
+ 2
+ 3
+
+julia> graph = GNNGraph((s, t), ndata = (; x=rand(Float32, 32, 3), y=rand(Float32, 3)), edata = rand(Float32, 2))
+GNNGraph:
+  num_nodes: 3
+  num_edges: 2
+  ndata:
+        y = 3-element Vector{Float32}
+        x = 32×3 Matrix{Float32}
+  edata:
+        e = 2-element Vector{Float32}
+
+julia> nodes = [1, 2]
+2-element Vector{Int64}:
+ 1
+ 2
+
+julia> subgraph = Graphs.induced_subgraph(graph, nodes)
+GNNGraph:
+  num_nodes: 2
+  num_edges: 1
+  ndata:
+        y = 2-element Vector{Float32}
+        x = 32×2 Matrix{Float32}
+  edata:
+        e = 1-element Vector{Float32}
 """
 function Graphs.induced_subgraph(graph::GNNGraph, nodes::Vector{Int})
     if isempty(nodes)

--- a/GNNGraphs/test/sampling.jl
+++ b/GNNGraphs/test/sampling.jl
@@ -61,6 +61,14 @@ if GRAPH_T == :coo
         @test subgraph.ndata.y == graph.ndata.y
         @test subgraph.edata == graph.edata
         
+        nodes = [1, 2]
+        subgraph = Graphs.induced_subgraph(graph, nodes)
+
+        @test subgraph.num_nodes == 2 
+        @test subgraph.num_edges == 1 
+        @test subgraph.ndata == getobs(graph.ndata, [1, 2])
+        @test subgraph.edata.e == getobs(graph.edata, 1)
+
         graph = GNNGraph(2)
         graph = add_edges(graph, ([2], [1]))
         nodes = [1]

--- a/GNNGraphs/test/sampling.jl
+++ b/GNNGraphs/test/sampling.jl
@@ -67,7 +67,7 @@ if GRAPH_T == :coo
         @test subgraph.num_nodes == 2 
         @test subgraph.num_edges == 1 
         @test subgraph.ndata == getobs(graph.ndata, [1, 2])
-        @test getobs(subgraph.edata.e) == getobs(graph.edata.e, 1)
+        @test isapprox(getobs(subgraph.edata.e, 1), getobs(graph.edata.e, 1); atol=1e-6)
 
         graph = GNNGraph(2)
         graph = add_edges(graph, ([2], [1]))

--- a/GNNGraphs/test/sampling.jl
+++ b/GNNGraphs/test/sampling.jl
@@ -67,7 +67,7 @@ if GRAPH_T == :coo
         @test subgraph.num_nodes == 2 
         @test subgraph.num_edges == 1 
         @test subgraph.ndata == getobs(graph.ndata, [1, 2])
-        @test subgraph.edata.e == getobs(graph.edata, 1)
+        @test getobs(subgraph.edata.e) == getobs(graph.edata.e, 1)
 
         graph = GNNGraph(2)
         graph = add_edges(graph, ([2], [1]))

--- a/GNNGraphs/test/sampling.jl
+++ b/GNNGraphs/test/sampling.jl
@@ -45,4 +45,20 @@ if GRAPH_T == :coo
         @test sg.ndata.x1 == g.ndata.x1[sg.ndata.NID]
         @test length(union(sg.ndata.NID)) == length(sg.ndata.NID)
     end
+
+    @testset "induced_subgraph" begin
+        # Create a simple GNNGraph with two nodes and one edge
+        graph = GNNGraph()  # Initialize graph
+        add_nodes!(graph, 2)  # Add 2 nodes
+        add_edge!(graph, 1, 2)  # Add an edge from node 1 to node 2
+        graph.x = rand(10, 2)  # Assign random features to both nodes (10 features per node)
+    
+        # Induce subgraph on both nodes
+        nodes = [1, 2]
+        subgraph = induced_subgraph(graph, nodes)
+    
+        @test num_nodes(subgraph) == 2  # Subgraph should have 2 nodes
+        @test num_nodes(subgraph) == 1  # Subgraph should have 1 edge
+        ### TODO @test subgraph.ndata.x == graph.x[:, nodes]  # Features should match the original graph
+    end
 end

--- a/GNNGraphs/test/sampling.jl
+++ b/GNNGraphs/test/sampling.jl
@@ -48,17 +48,17 @@ if GRAPH_T == :coo
 
     @testset "induced_subgraph" begin
         # Create a simple GNNGraph with two nodes and one edge
-        graph = GNNGraph()  # Initialize graph
-        add_nodes!(graph, 2)  # Add 2 nodes
-        add_edge!(graph, 1, 2)  # Add an edge from node 1 to node 2
-        graph.x = rand(10, 2)  # Assign random features to both nodes (10 features per node)
-    
+        s = [1]
+        t = [2]
+        ### TODO add data
+        graph = GNNGraph((s, t))
+        
         # Induce subgraph on both nodes
         nodes = [1, 2]
         subgraph = induced_subgraph(graph, nodes)
     
         @test num_nodes(subgraph) == 2  # Subgraph should have 2 nodes
-        @test num_nodes(subgraph) == 1  # Subgraph should have 1 edge
+        @test num_edges(subgraph) == 1  # Subgraph should have 1 edge
         ### TODO @test subgraph.ndata.x == graph.x[:, nodes]  # Features should match the original graph
     end
 end

--- a/GNNGraphs/test/sampling.jl
+++ b/GNNGraphs/test/sampling.jl
@@ -57,8 +57,8 @@ if GRAPH_T == :coo
         nodes = [1, 2]
         subgraph = induced_subgraph(graph, nodes)
     
-        @test num_nodes(subgraph) == 2  # Subgraph should have 2 nodes
-        @test num_edges(subgraph) == 1  # Subgraph should have 1 edge
+        @test subgraph.num_nodes == 2  # Subgraph should have 2 nodes
+        @test subgraph.num_edges == 1  # Subgraph should have 1 edge
         ### TODO @test subgraph.ndata.x == graph.x[:, nodes]  # Features should match the original graph
     end
 end

--- a/GNNGraphs/test/sampling.jl
+++ b/GNNGraphs/test/sampling.jl
@@ -47,18 +47,26 @@ if GRAPH_T == :coo
     end
 
     @testset "induced_subgraph" begin
-        # Create a simple GNNGraph with two nodes and one edge
-        s = [1]
-        t = [2]
-        ### TODO add data
-        graph = GNNGraph((s, t))
+        s = [1, 2]
+        t = [2, 3]
         
-        # Induce subgraph on both nodes
-        nodes = [1, 2]
-        subgraph = induced_subgraph(graph, nodes)
-    
-        @test subgraph.num_nodes == 2  # Subgraph should have 2 nodes
-        @test subgraph.num_edges == 1  # Subgraph should have 1 edge
-        ### TODO @test subgraph.ndata.x == graph.x[:, nodes]  # Features should match the original graph
+        graph = GNNGraph((s, t), ndata = (; x=rand(Float32, 32, 3), y=rand(Float32, 3)), edata = rand(Float32, 2))
+        
+        nodes = [1, 2, 3]
+        subgraph = Graphs.induced_subgraph(graph, nodes)
+        
+        @test subgraph.num_nodes == 3  
+        @test subgraph.num_edges == 2  
+        @test subgraph.ndata.x == graph.ndata.x
+        @test subgraph.ndata.y == graph.ndata.y
+        @test subgraph.edata == graph.edata
+        
+        graph = GNNGraph(2)
+        graph = add_edges(graph, ([2], [1]))
+        nodes = [1]
+        subgraph = Graphs.induced_subgraph(graph, nodes)
+        
+        @test subgraph.num_nodes == 1 
+        @test subgraph.num_edges == 0 
     end
 end

--- a/GraphNeuralNetworks/docs/src/api/gnngraph.md
+++ b/GraphNeuralNetworks/docs/src/api/gnngraph.md
@@ -88,3 +88,7 @@ Modules = [GNNGraphs]
 Pages   = ["sampling.jl"]
 Private = false
 ```
+
+```@docs
+Graphs.induced_subgraph(::GNNGraph, ::Vector{Int})
+```

--- a/GraphNeuralNetworks/src/GraphNeuralNetworks.jl
+++ b/GraphNeuralNetworks/src/GraphNeuralNetworks.jl
@@ -12,7 +12,7 @@ using Reexport
 using MLUtils: zeros_like
 
 using GNNGraphs:  induced_subgraph,
-                  COO_T, ADJMAT_T, SPARSE_T,
+                  COO_T, ADJMAT_T, SPARSE_T,321
                   check_num_nodes, check_num_edges,
                   EType, NType # for heteroconvs
 

--- a/GraphNeuralNetworks/src/GraphNeuralNetworks.jl
+++ b/GraphNeuralNetworks/src/GraphNeuralNetworks.jl
@@ -12,7 +12,7 @@ using Reexport
 using MLUtils: zeros_like
 
 using GNNGraphs:  induced_subgraph,
-                  COO_T, ADJMAT_T, SPARSE_T,321
+                  COO_T, ADJMAT_T, SPARSE_T,
                   check_num_nodes, check_num_edges,
                   EType, NType # for heteroconvs
 

--- a/GraphNeuralNetworks/src/GraphNeuralNetworks.jl
+++ b/GraphNeuralNetworks/src/GraphNeuralNetworks.jl
@@ -11,7 +11,8 @@ using ChainRulesCore
 using Reexport
 using MLUtils: zeros_like
 
-using GNNGraphs: COO_T, ADJMAT_T, SPARSE_T,
+using GNNGraphs:  induced_subgraph,
+                  COO_T, ADJMAT_T, SPARSE_T,
                   check_num_nodes, check_num_edges,
                   EType, NType # for heteroconvs
 

--- a/GraphNeuralNetworks/src/GraphNeuralNetworks.jl
+++ b/GraphNeuralNetworks/src/GraphNeuralNetworks.jl
@@ -11,8 +11,7 @@ using ChainRulesCore
 using Reexport
 using MLUtils: zeros_like
 
-using GNNGraphs:  induced_subgraph,
-                  COO_T, ADJMAT_T, SPARSE_T,
+using GNNGraphs:  COO_T, ADJMAT_T, SPARSE_T,
                   check_num_nodes, check_num_edges,
                   EType, NType # for heteroconvs
 


### PR DESCRIPTION
This PR introduces `induced_subgraph` functionality to match `Graphs` [interface](https://juliagraphs.org/Graphs.jl/stable/core_functions/operators/#Graphs.induced_subgraph-Union%7BTuple%7BT%7D,%20Tuple%7BU%7D,%20Tuple%7BT,%20AbstractVector%7BU%7D%7D%7D%20where%20%7BU%3C:Integer,%20T%3C:AbstractGraph%7D).


As per @CarloLucibello comment in the #495

> Notice that we already have the very similar function [sample_neighbors](https://github.com/CarloLucibello/GraphNeuralNetworks.jl/blob/a034753acee5187dc1e1b85e209d6d2a9b2b7e34/GNNGraphs/src/sampling.jl#L2) in GNNGraphs.jl. Let's implement induced_interface as well in order to be Graphs.jl compliant. 

