### PR TITLE
fix vector DataStore

### DIFF
--- a/GNNGraphs/src/GNNGraphs.jl
+++ b/GNNGraphs/src/GNNGraphs.jl
@@ -111,4 +111,6 @@ include("gatherscatter.jl")
 include("mldatasets.jl")
 export mldataset2gnngraph
 
+include("deprecations.jl")
+
 end #module

--- a/GNNGraphs/src/datastore.jl
+++ b/GNNGraphs/src/datastore.jl
@@ -107,16 +107,6 @@ function Base.getproperty(ds::DataStore, s::Symbol)
     end
 end
 
-function Base.getproperty(vds::Vector{DataStore}, s::Symbol)
-    if s === :_n
-        return [getn(ds) for ds in vds]
-    elseif s === :_data
-        return [getdata(ds) for ds in vds]
-    else
-        return [getdata(ds)[s] for ds in vds]
-    end
-end
-
 function Base.setproperty!(ds::DataStore, s::Symbol, x)
     @assert s != :_n "cannot set _n directly"
     @assert s != :_data "cannot set _data directly"

--- a/GNNGraphs/src/datastore.jl
+++ b/GNNGraphs/src/datastore.jl
@@ -107,6 +107,8 @@ function Base.getproperty(ds::DataStore, s::Symbol)
     end
 end
 
+
+
 function Base.setproperty!(ds::DataStore, s::Symbol, x)
     @assert s != :_n "cannot set _n directly"
     @assert s != :_data "cannot set _data directly"

--- a/GNNGraphs/src/deprecations.jl
+++ b/GNNGraphs/src/deprecations.jl
@@ -1,0 +1,13 @@
+## Deprecated in V0.6
+
+function Base.getproperty(vds::Vector{DataStore}, s::Symbol)
+    if s ∈ (:ref, :size) # these are arrays fields in V0.11
+        return getfield(vds, s)
+    elseif s === :_n
+        return [getn(ds) for ds in vds]
+    elseif s === :_data
+        return [getdata(ds) for ds in vds]
+    else
+        return [getdata(ds)[s] for ds in vds]
+    end
+end

--- a/GNNGraphs/test/datastore.jl
+++ b/GNNGraphs/test/datastore.jl
@@ -20,6 +20,9 @@ end
     @test_throws DimensionMismatch ds.z=rand(12)
     ds.z = [1:10;]
     @test ds.z == [1:10;]
+
+    # issue #504
+    vec = [DataStore(10, (:x => x,)), DataStore(10, (:x => x, :y => rand(2, 10)))]
 end
 
 @testset "setindex!" begin

--- a/GNNGraphs/test/datastore.jl
+++ b/GNNGraphs/test/datastore.jl
@@ -21,8 +21,8 @@ end
     ds.z = [1:10;]
     @test ds.z == [1:10;]
 
-    # issue #504
-    vec = [DataStore(10, (:x => x,)), DataStore(10, (:x => x, :y => rand(2, 10)))]
+    # issue #504, where vector creation failed
+    @test fill(DataStore(), 3) isa Vector
 end
 
 @testset "setindex!" begin

--- a/GNNGraphs/test/datastore.jl
+++ b/GNNGraphs/test/datastore.jl
@@ -20,11 +20,6 @@ end
     @test_throws DimensionMismatch ds.z=rand(12)
     ds.z = [1:10;]
     @test ds.z == [1:10;]
-    vec = [DataStore(10, (:x => x,)), DataStore(10, (:x => x, :y => rand(2, 10)))]
-    @test vec.x == [x, x]
-    @test_throws KeyError vec.z 
-    @test vec._n == [10, 10]
-    @test vec._data == [Dict(:x => x), Dict(:x => x, :y => vec[2].y)]
 end
 
 @testset "setindex!" begin

--- a/GraphNeuralNetworks/docs/src/temporalgraph.md
+++ b/GraphNeuralNetworks/docs/src/temporalgraph.md
@@ -91,15 +91,15 @@ GNNGraph:
 ```
 
 ## Data Features
-
-Node, edge, and graph features can be added at construction time or later using:
+A temporal graph can stode global feautre for the entire time series in the `tgdata` filed.
+Also, each snapshot can store node, edge, and graph features in the `ndata`, `edata`, and `gdata` fields, respectively. 
 
 ```jldoctest
 julia> snapshots = [rand_graph(10,20; ndata = rand(3,10)), rand_graph(10,14; ndata = rand(4,10)), rand_graph(10,22; ndata = rand(5,10))]; # node features at construction time
 
 julia> tg = TemporalSnapshotsGNNGraph(snapshots);
 
-julia> tg.tgdata.y = rand(3,1); # graph features after construction
+julia> tg.tgdata.y = rand(3,1); # add global features after construction
 
 julia> tg
 TemporalSnapshotsGNNGraph:
@@ -109,7 +109,7 @@ TemporalSnapshotsGNNGraph:
   tgdata:
         y = 3×1 Matrix{Float64}
 
-julia> tg.ndata # vector of Datastore for node features
+julia> tg.ndata # vector of DataStore containing node features for each snapshot
 3-element Vector{DataStore}:
  DataStore(10) with 1 element:
   x = 3×10 Matrix{Float64}
@@ -118,8 +118,10 @@ julia> tg.ndata # vector of Datastore for node features
  DataStore(10) with 1 element:
   x = 5×10 Matrix{Float64}
 
-julia> typeof(tg.ndata.x) # vector containing the x feature of each snapshot
-Vector{Matrix{Float64}}
+julia> [ds.x for ds in tg.ndata]; # vector containing the x feature of each snapshot
+
+julia> [g.x for g in tg.snapshots]; # same vector as above, now accessing 
+                                   # the x feature directly from the snapshots
 ```
 
 ## Graph convolutions on TemporalSnapshotsGNNGraph


### PR DESCRIPTION
fix #504. Also deprecates `getproperty(Vector{DataStore},...) since it is frail.