### PR TITLE
Export is_coalesced in GNNGraphs module

### DIFF
--- a/GNNGraphs/src/GNNGraphs.jl
+++ b/GNNGraphs/src/GNNGraphs.jl
@@ -55,6 +55,7 @@ export adjacency_list,
        normalized_laplacian,
        scaled_laplacian,
        laplacian_lambda_max,
+       is_coalesced,
 # from Graphs.jl
        adjacency_matrix,
        degree,


### PR DESCRIPTION
Exports the `is_coalesced` function to check whether a graph is coalesced or not.