### PR TITLE
fix: Empty edge handling in `softmax_edge_neighbors`

### DIFF
--- a/GNNlib/src/utils.jl
+++ b/GNNlib/src/utils.jl
@@ -91,7 +91,7 @@ function softmax_edge_neighbors(g::AbstractGNNGraph, e)
     end
     s, t = edge_index(g)
     if isempty(t)
-        return zero(eltype(e))
+        return zeros_like(e, eltype(e), (size(e)[1:end-1]..., 0))
     end
     max_ = gather(scatter(max, e, t), t)
     num = exp.(e .- max_)


### PR DESCRIPTION
Resolves #635 

If there is a node type that has no edges, `softmax_edge_neighbors` should output an empty array.