### PR TITLE
Fix/remove self loops adjmat mutation

### DIFF
--- a/GNNGraphs/src/transform.jl
+++ b/GNNGraphs/src/transform.jl
@@ -65,7 +65,7 @@ end
 
 function remove_self_loops(g::GNNGraph{<:ADJMAT_T})
     @assert isempty(g.edata)
-    A = g.graph
+    A = copy(g.graph)
     A[diagind(A)] .= 0
     if A isa AbstractSparseMatrix
         dropzeros!(A)

--- a/GNNGraphs/test/transform.jl
+++ b/GNNGraphs/test/transform.jl
@@ -341,6 +341,20 @@ end
             @test size(get_edge_weight(g2)) == (g2.num_edges,)
             @test size(g2.edata.e1) == (3, g2.num_edges)
             @test size(g2.edata.e2) == (g2.num_edges,)
+        else
+            A = [1 1 0
+                 0 1 1
+                 1 0 0]
+            A_no_loops = [0 1 0
+                          0 0 1
+                          1 0 0]
+            g = GNNGraph(A; graph_type = GRAPH_T)
+            g2 = remove_self_loops(g)
+
+            @test Matrix(adjacency_matrix(g)) == A
+            @test Matrix(adjacency_matrix(g2)) == A_no_loops
+            @test g2.num_edges == count(!iszero, A_no_loops)
+            @test g.graph !== g2.graph
         end 
     end
 end


### PR DESCRIPTION
closes #658 

Now the graph will be copied so that it does not mutate the original graph in place.

I have also added tests for remove_self_loops for dense graph as well
