### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,8 +10,7 @@ steps:
             - GraphNeuralNetworks/src
             - GraphNeuralNetworks/ext
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     env:
       GNN_TEST_CUDA: "true"
       GNN_TEST_CPU: "false"
@@ -28,8 +27,7 @@ steps:
             - GraphNeuralNetworks/src
             - GraphNeuralNetworks/ext
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
       rocmgpu: "*"
     env:
       GNN_TEST_AMDGPU: "true"
@@ -47,8 +45,7 @@ steps:
             - GNNlib/src
             - GNNlib/ext
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     env:
       GNN_TEST_CUDA: "true"
       GNN_TEST_CPU: "false"
@@ -65,8 +62,7 @@ steps:
             - GNNlib/src
             - GNNlib/ext
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
       rocmgpu: "*"
     env:
       GNN_TEST_AMDGPU: "true"
@@ -85,8 +81,7 @@ steps:
             - GNNGraphs/src
             - GNNGraphs/ext
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     env:
       GNN_TEST_CUDA: "true"
       GNN_TEST_CPU: "false"
@@ -103,8 +98,7 @@ steps:
             - GNNGraphs/src
             - GNNGraphs/ext
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
       rocmgpu: "*"
     env:
       GNN_TEST_AMDGPU: "true"


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)