### PR TITLE
Add Mooncake rule for propagate e_mul_xj fast path and added tests

### DIFF
--- a/GNNlib/ext/GNNlibMooncakeExt.jl
+++ b/GNNlib/ext/GNNlibMooncakeExt.jl
@@ -1,17 +1,14 @@
 module GNNlibMooncakeExt
 
-using GNNlib: GNNlib, propagate, copy_xj
-using GNNGraphs: GNNGraph, adjacency_matrix
+using GNNlib: GNNlib, propagate, copy_xj, e_mul_xj
+using GNNGraphs: GNNGraph, adjacency_matrix, edge_index, set_edge_weight
 using LinearAlgebra: adjoint
 using Base: IEEEFloat
 import Mooncake
 using Mooncake: CoDual, DefaultCtx, NoRData, @is_primitive
 
-# Mooncake reverse rule for the sparse message-passing fast path
-#     propagate(copy_xj, g, +, xi, xj, e)  ==  xj * adjacency_matrix(g)
-# `A` is constant w.r.t. the inputs, so the pullback is just `dxj = dy * A'`.
-# Without it Mooncake differentiates the generic sparse matmul, which is far
-# slower than Zygote.
+# Reverse rule for the fast path `propagate(copy_xj, g, +, xj) == xj * A`.
+# `A` is constant w.r.t. the inputs, so `dxj = dy * A'`.
 
 @is_primitive DefaultCtx Tuple{
     typeof(propagate),
@@ -45,6 +42,47 @@ function Mooncake.rrule!!(
                NoRData(), NoRData(), NoRData(), NoRData()
     end
     return res, propagate_copy_xj_add_pullback!!
+end
+
+# Reverse rule for the weighted fast path `propagate(e_mul_xj, g, +, xj, e) == xj * A(e)`.
+# `e` enters `A`, so we also return `de_k = Σ_f xj[f, s_k] * dy[f, t_k]`.
+
+@is_primitive DefaultCtx Tuple{
+    typeof(propagate),
+    typeof(e_mul_xj),
+    GNNGraph,
+    typeof(+),
+    Nothing,
+    AbstractMatrix{P},
+    AbstractVector{P},
+} where {P <: IEEEFloat}
+
+function Mooncake.rrule!!(
+    ::CoDual{typeof(propagate)},
+    ::CoDual{typeof(e_mul_xj)},
+    g::CoDual{<:GNNGraph},
+    ::CoDual{typeof(+)},
+    ::CoDual{Nothing},
+    xj::CoDual{<:AbstractMatrix{P}},
+    e::CoDual{<:AbstractVector{P}},
+) where {P <: IEEEFloat}
+    pg = Mooncake.primal(g)
+    pxj = Mooncake.primal(xj)
+    pe = Mooncake.primal(e)
+    s, t = edge_index(pg)
+    A = adjacency_matrix(set_edge_weight(pg, pe), P; weighted = true)
+    y = pxj * A
+    res = Mooncake.zero_fcodual(y)
+    function propagate_e_mul_xj_add_pullback!!(::NoRData)
+        dy = Mooncake.tangent(res)
+        dxj = Mooncake.tangent(xj)
+        de = Mooncake.tangent(e)
+        dxj .+= dy * adjoint(A)
+        de .+= vec(sum(view(pxj, :, s) .* view(dy, :, t); dims = 1))
+        return NoRData(), NoRData(), Mooncake.zero_rdata(pg),
+               NoRData(), NoRData(), NoRData(), NoRData()
+    end
+    return res, propagate_e_mul_xj_add_pullback!!
 end
 
 end # module

--- a/GNNlib/test/msgpass.jl
+++ b/GNNlib/test/msgpass.jl
@@ -151,6 +151,16 @@ end
         end
     end
 
+    @testset "e_mul_xj + (scalar edge weight)" begin
+        # Scalar per-edge weights hit the spmm fast path that GNNlibMooncakeExt
+        # has a dedicated Mooncake rule for (matrix `e` above stays generic).
+        for g in TEST_GRAPHS
+            e = rand(Float32, g.num_edges)
+            f(g, x, e) = propagate(e_mul_xj, g, +; xj = x, e)
+            test_gradients(f, g, g.x, e; test_grad_f=false, test_mooncake=TEST_MOONCAKE)
+        end
+    end
+
     @testset "w_mul_xj +" begin
         for g in TEST_GRAPHS
             w = rand(Float32, g.num_edges)


### PR DESCRIPTION
I have added the propagate `e_mul_xj` fast path. This pr depends on #677 so that should be merged first.

# Benchmark Results

#### The rules matched for the following layers, the improvements and the benchmarks are listed below, all layers pass the gradient correctness benchmarks:

<details open>
<summary><b>GCNConv</b></summary>

```text
[n=512]
  grad-check PASS

  Zygote             Zyg     1.460 ms /   2501 alloc
  Mooncake + RULE     MC     2.882 ms /    473 alloc   (MC+rule / Zyg =  1.97x)
  Mooncake - rule     MC     9.504 ms /    665 alloc   (no-rule / Zyg =  6.51x)

  >>> RULE SPEEDUP (no-rule / +rule) =  3.30x

[n=2048]
  grad-check PASS

  Zygote             Zyg     7.601 ms /   2501 alloc
  Mooncake + RULE     MC    15.561 ms /    473 alloc   (MC+rule / Zyg =  2.05x)
  Mooncake - rule     MC    39.605 ms /    665 alloc   (no-rule / Zyg =  5.21x)

  >>> RULE SPEEDUP (no-rule / +rule) =  2.55x

[n=8192]
  grad-check PASS

  Zygote             Zyg   125.052 ms /   2501 alloc
  Mooncake + RULE     MC   132.897 ms /    473 alloc   (MC+rule / Zyg =  1.06x)
  Mooncake - rule     MC   467.868 ms /    665 alloc   (no-rule / Zyg =  3.74x)

  >>> RULE SPEEDUP (no-rule / +rule) =  3.52x
```

</details>

<details>
<summary><b>SGConv (k=2)</b></summary>

```text
[n=512]
  grad-check PASS

  Zygote             Zyg     2.791 ms /   4150 alloc
  Mooncake + RULE     MC     4.762 ms /    560 alloc   (MC+rule / Zyg =  1.71x)
  Mooncake - rule     MC    18.177 ms /    946 alloc   (no-rule / Zyg =  6.51x)

  >>> RULE SPEEDUP (no-rule / +rule) =  3.82x

[n=2048]
  grad-check PASS

  Zygote             Zyg    10.970 ms /   4150 alloc
  Mooncake + RULE     MC    18.078 ms /    560 alloc   (MC+rule / Zyg =  1.65x)
  Mooncake - rule     MC    75.055 ms /    946 alloc   (no-rule / Zyg =  6.84x)

  >>> RULE SPEEDUP (no-rule / +rule) =  4.15x

[n=8192]
  grad-check PASS

  Zygote             Zyg   233.485 ms /   4150 alloc
  Mooncake + RULE     MC   206.554 ms /    560 alloc   (MC+rule / Zyg =  0.88x)
  Mooncake - rule     MC   944.392 ms /    946 alloc   (no-rule / Zyg =  4.04x)

  >>> RULE SPEEDUP (no-rule / +rule) =  4.57x
```

</details>

<details>
<summary><b>TAGConv (k=2)</b></summary>

```text
[n=512]
  grad-check PASS

  Zygote             Zyg     3.412 ms /   4195 alloc
  Mooncake + RULE     MC     5.849 ms /    593 alloc   (MC+rule / Zyg =  1.71x)
  Mooncake - rule     MC    20.454 ms /    979 alloc   (no-rule / Zyg =  5.99x)

  >>> RULE SPEEDUP (no-rule / +rule) =  3.50x

[n=2048]
  grad-check PASS

  Zygote             Zyg    12.748 ms /   4195 alloc
  Mooncake + RULE     MC    29.878 ms /    593 alloc   (MC+rule / Zyg =  2.34x)
  Mooncake - rule     MC    75.978 ms /    979 alloc   (no-rule / Zyg =  5.96x)

  >>> RULE SPEEDUP (no-rule / +rule) =  2.54x

[n=8192]
  grad-check PASS

  Zygote             Zyg   198.058 ms /   4195 alloc
  Mooncake + RULE     MC   267.873 ms /    593 alloc   (MC+rule / Zyg =  1.35x)
  Mooncake - rule     MC   957.197 ms /    979 alloc   (no-rule / Zyg =  4.83x)

  >>> RULE SPEEDUP (no-rule / +rule) =  3.57x
```

</details>

I have also added an extra test for this change.