### PR TITLE
Add reverse rule for copy_xj mean fast path in Mooncake Ext

### DIFF
--- a/GNNlib/ext/GNNlibMooncakeExt.jl
+++ b/GNNlib/ext/GNNlibMooncakeExt.jl
@@ -1,8 +1,9 @@
 module GNNlibMooncakeExt
 
 using GNNlib: GNNlib, propagate, copy_xj, e_mul_xj, w_mul_xj
-using GNNGraphs: GNNGraph, adjacency_matrix, edge_index, set_edge_weight
-using LinearAlgebra: adjoint
+using GNNGraphs: GNNGraph, adjacency_matrix, degree, edge_index, set_edge_weight
+using LinearAlgebra: Diagonal, adjoint
+using Statistics: mean
 using Base: IEEEFloat
 import Mooncake
 using Mooncake: CoDual, DefaultCtx, NoRData, @is_primitive
@@ -134,6 +135,47 @@ function Mooncake.rrule!!(
                NoRData(), NoRData(), NoRData(), NoRData()
     end
     return res, propagate_w_mul_xj_add_pullback!!
+end
+
+# Reverse rule for the mean fast path `propagate(copy_xj, g, mean, xj) == xj * Â`,
+# with `Â = A * Diagonal(dinv)` the in-degree-normalized adjacency. Isolated
+# nodes get 0, matching `NNlib.scatter(mean, ...)`. `Â` is constant w.r.t. the
+# inputs, so `dxj = dy * Â'`.
+
+@is_primitive DefaultCtx Tuple{
+    typeof(propagate),
+    typeof(copy_xj),
+    GNNGraph,
+    typeof(mean),
+    Nothing,
+    AbstractMatrix{P},
+    Nothing,
+} where {P <: IEEEFloat}
+
+function Mooncake.rrule!!(
+    ::CoDual{typeof(propagate)},
+    ::CoDual{typeof(copy_xj)},
+    g::CoDual{<:GNNGraph},
+    ::CoDual{typeof(mean)},
+    ::CoDual{Nothing},
+    xj::CoDual{<:AbstractMatrix{P}},
+    ::CoDual{Nothing},
+) where {P <: IEEEFloat}
+    pg = Mooncake.primal(g)
+    pxj = Mooncake.primal(xj)
+    d = degree(pg, P; dir = :in, edge_weight = false)
+    dinv = map(x -> ifelse(iszero(x), zero(P), inv(x)), d)
+    A = adjacency_matrix(pg, P; weighted = false) * Diagonal(dinv)
+    y = pxj * A
+    res = Mooncake.zero_fcodual(y)
+    function propagate_copy_xj_mean_pullback!!(::NoRData)
+        dy = Mooncake.tangent(res)
+        dxj = Mooncake.tangent(xj)
+        dxj .+= dy * adjoint(A)
+        return NoRData(), NoRData(), Mooncake.zero_rdata(pg),
+               NoRData(), NoRData(), NoRData(), NoRData()
+    end
+    return res, propagate_copy_xj_mean_pullback!!
 end
 
 end # module


### PR DESCRIPTION
# Benchmark Results

#### The cppy_xj mean rule matched for the following layers, the improvements and the benchmarks are listed below, all layers pass the gradient correctness benchmarks. This rule shows big improvement on larger sizes surpassing Zygote by a big margin.

<details open>
<summary><b>SAGEConv</b></summary>

```text
[n=512]
  grad-check PASS

  Zygote             Zyg     1.153 ms /    802 alloc
  Mooncake + RULE     MC     1.813 ms /    209 alloc   (MC+rule / Zyg =   1.57x)
  Mooncake - rule     MC     7.225 ms /    259 alloc   (no-rule / Zyg =   6.27x)

  >>> RULE SPEEDUP (no-rule / +rule) =   3.99x

[n=2048]
  grad-check PASS

  Zygote             Zyg     3.985 ms /    802 alloc
  Mooncake + RULE     MC     7.505 ms /    209 alloc   (MC+rule / Zyg =   1.88x)
  Mooncake - rule     MC    26.110 ms /    259 alloc   (no-rule / Zyg =   6.55x)

  >>> RULE SPEEDUP (no-rule / +rule) =   3.48x

[n=8192]
  grad-check PASS

  Zygote             Zyg   204.203 ms /    802 alloc
  Mooncake + RULE     MC    64.614 ms /    209 alloc   (MC+rule / Zyg =   0.32x)
  Mooncake - rule     MC   477.767 ms /    259 alloc   (no-rule / Zyg =   2.34x)

  >>> RULE SPEEDUP (no-rule / +rule) =   7.39x
```

</details>

<details>
<summary><b>GraphConv (aggr=mean)</b></summary>

```text
[n=512]
  grad-check PASS

  Zygote             Zyg     1.111 ms /    813 alloc
  Mooncake + RULE     MC     1.497 ms /    219 alloc   (MC+rule / Zyg =   1.35x)
  Mooncake - rule     MC     6.252 ms /    269 alloc   (no-rule / Zyg =   5.63x)

  >>> RULE SPEEDUP (no-rule / +rule) =   4.18x

[n=2048]
  grad-check PASS

  Zygote             Zyg     3.777 ms /    813 alloc
  Mooncake + RULE     MC     6.182 ms /    219 alloc   (MC+rule / Zyg =   1.64x)
  Mooncake - rule     MC    24.117 ms /    269 alloc   (no-rule / Zyg =   6.39x)

  >>> RULE SPEEDUP (no-rule / +rule) =   3.90x

[n=8192]
  grad-check PASS

  Zygote             Zyg   146.489 ms /    813 alloc
  Mooncake + RULE     MC    52.100 ms /    219 alloc   (MC+rule / Zyg =   0.36x)
  Mooncake - rule     MC   475.124 ms /    269 alloc   (no-rule / Zyg =   3.24x)

  >>> RULE SPEEDUP (no-rule / +rule) =   9.12x
```

</details>

<details>
<summary><b>GatedGraphConv (mean)</b></summary>

```text
[n=512]
  grad-check PASS

  Zygote             Zyg     5.232 ms /   3819 alloc
  Mooncake + RULE     MC    15.447 ms /   2345 alloc   (MC+rule / Zyg =   2.95x)
  Mooncake - rule     MC    24.691 ms /   2445 alloc   (no-rule / Zyg =   4.72x)

  >>> RULE SPEEDUP (no-rule / +rule) =   1.60x

[n=2048]
  grad-check PASS

  Zygote             Zyg    21.712 ms /   3819 alloc
  Mooncake + RULE     MC    62.760 ms /   2345 alloc   (MC+rule / Zyg =   2.89x)
  Mooncake - rule     MC    94.784 ms /   2445 alloc   (no-rule / Zyg =   4.37x)

  >>> RULE SPEEDUP (no-rule / +rule) =   1.51x

[n=8192]
  grad-check PASS

  Zygote             Zyg   858.547 ms /   3819 alloc
  Mooncake + RULE     MC   572.418 ms /   2345 alloc   (MC+rule / Zyg =   0.67x)
  Mooncake - rule     MC  1562.879 ms /   2445 alloc   (no-rule / Zyg =   1.82x)

  >>> RULE SPEEDUP (no-rule / +rule) =   2.73x
```

</details>