### PR TITLE
Work around Julia 1.12 Zygote codegen segfault in CGConv/GMMConv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries link to the pull request that introduced them.
 ## GNNlib.jl — Unreleased (towards 1.3.1)
 
 **Fixed**
-- Worked around a Julia 1.12 code-generation segfault that crashed `CGConv` and `GMMConv` gradients: the layers' `@warn` (in the residual branch) is now wrapped in `ignore_derivatives` to keep the logging macro out of the AD-differentiated code path. Root cause reported upstream as [FluxML/Zygote.jl#1662]; re-enables the previously disabled `CGConv`/`GMMConv` gradient tests ([#623]).
+- Worked around a Julia 1.12 code-generation segfault that crashed `CGConv` and `GMMConv` gradients: the layers' `@warn` (in the residual branch) is now wrapped in `ignore_derivatives` to keep the logging macro out of the AD-differentiated code path. Root cause reported upstream as [FluxML/Zygote.jl#1662]; re-enables the previously disabled `CGConv`/`GMMConv` gradient tests ([#695]).
 
 ## GNNLux.jl — Unreleased (towards 0.2.0)
 
@@ -204,4 +204,5 @@ Lux implementations of the graph convolutional, pooling, and temporal layers
 [#690]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/690
 [#691]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/691
 [#623]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/issues/623
+[#695]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/695
 [FluxML/Zygote.jl#1662]: https://github.com/FluxML/Zygote.jl/issues/1662

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the packages adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Entries link to the pull request that introduced them.
 
+## GNNlib.jl — Unreleased (towards 1.3.1)
+
+**Fixed**
+- Worked around a Julia 1.12 code-generation segfault that crashed `CGConv` and `GMMConv` gradients: the layers' `@warn` (in the residual branch) is now wrapped in `ignore_derivatives` to keep the logging macro out of the AD-differentiated code path. Root cause reported upstream as [FluxML/Zygote.jl#1662]; re-enables the previously disabled `CGConv`/`GMMConv` gradient tests ([#623]).
+
 ## GNNLux.jl — Unreleased (towards 0.2.0)
 
 **Added**
@@ -198,3 +203,5 @@ Lux implementations of the graph convolutional, pooling, and temporal layers
 [#687]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/687
 [#690]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/690
 [#691]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/691
+[#623]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/issues/623
+[FluxML/Zygote.jl#1662]: https://github.com/FluxML/Zygote.jl/issues/1662

--- a/GNNLux/test/layers/conv.jl
+++ b/GNNLux/test/layers/conv.jl
@@ -33,11 +33,10 @@
         test_lux_layer(rng, l, g, x, sizey=(out_dims,10), container=true)
     end
     
-    ## TODO SEGFAULT on julia 1.12
-    # @testset  "CGConv" begin
-    #     l = CGConv(in_dims => in_dims, residual = true)
-    #     test_lux_layer(rng, l, g, x, outputsize=(in_dims,), container=true)
-    # end
+    @testset  "CGConv" begin
+        l = CGConv(in_dims => in_dims, residual = true)
+        test_lux_layer(rng, l, g, x, outputsize=(in_dims,), container=true)
+    end
 
     @testset "DConv" begin
         l = DConv(in_dims => out_dims, 2)
@@ -126,13 +125,12 @@
         test_lux_layer(rng, l, g2, x; outputsize=(n_out,), e, container=true)
     end
 
-    ## TODO SEGFAULT on julia 1.12
-    # @testset "GMMConv" begin
-    #     ein_dims = 4 
-    #     e = randn(rng, Float32, ein_dims, g.num_edges)
-    #     l = GMMConv((in_dims, ein_dims) => out_dims, tanh; K = 2, residual = false)
-    #     test_lux_layer(rng, l, g, x; outputsize=(out_dims,), e)
-    # end
+    @testset "GMMConv" begin
+        ein_dims = 4
+        e = randn(rng, Float32, ein_dims, g.num_edges)
+        l = GMMConv((in_dims, ein_dims) => out_dims, tanh; K = 2, residual = false)
+        test_lux_layer(rng, l, g, x; outputsize=(out_dims,), e)
+    end
 
     @testset "ResGatedGraphConv" begin
         l = ResGatedGraphConv(in_dims => out_dims, tanh)

--- a/GNNlib/Project.toml
+++ b/GNNlib/Project.toml
@@ -1,7 +1,7 @@
 name = "GNNlib"
 uuid = "a6a84749-d869-43f8-aacc-be26a1996e48"
 authors = ["Carlo Lucibello and contributors"]
-version = "1.3.0"
+version = "1.3.1-DEV"
 
 [workspace]
 projects = ["test", "docs", "../GNNGraphs"]

--- a/GNNlib/src/layers/conv.jl
+++ b/GNNlib/src/layers/conv.jl
@@ -316,7 +316,13 @@ function cg_conv(l, g::AbstractGNNGraph, x, e::Union{Nothing, AbstractMatrix} = 
         if size(x, 1) == size(m, 1)
             m += x
         else
-            @warn "number of output features different from number of input features, residual not applied."
+            # `@warn` is wrapped in `ignore_derivatives` to keep the logging
+            # macro out of the AD-differentiated code path: a `@warn`/`@info`
+            # inside a Zygote-differentiated branch segfaults on Julia 1.12
+            # (FluxML/Zygote.jl#1662, GraphNeuralNetworks.jl#623).
+            ignore_derivatives() do
+                @warn "number of output features different from number of input features, residual not applied."
+            end
         end
     end
 
@@ -393,7 +399,11 @@ function gmm_conv(l, g::GNNGraph, x::AbstractMatrix, e::AbstractMatrix)
         if size(x, 1) == size(m, 1)
             m += x
         else
-            @warn "Residual not applied : output feature is not equal to input_feature"
+            # see the note in `cg_conv`: keep `@warn` out of the AD path to
+            # avoid the Julia 1.12 codegen segfault (FluxML/Zygote.jl#1662).
+            ignore_derivatives() do
+                @warn "Residual not applied : output feature is not equal to input_feature"
+            end
         end
     end
 

--- a/GraphNeuralNetworks/test/layers/conv.jl
+++ b/GraphNeuralNetworks/test/layers/conv.jl
@@ -365,24 +365,23 @@ end
     end   
 end
 
-## TODO segfault on julia v1.12
-# @testitem "CGConv" setup=[TolSnippet, TestModule] begin
-#     using .TestModule
+@testitem "CGConv" setup=[TolSnippet, TestModule] begin
+    using .TestModule
 
-#     edim = 10
-#     l = CGConv((D_IN, edim) => D_OUT, tanh, residual = false, bias = true)
-#     for g in TEST_GRAPHS
-#         g = GNNGraph(g, edata = rand(Float32, edim, g.num_edges))
-#         @test size(l(g, g.x, g.e)) == (D_OUT, g.num_nodes)
-#         test_gradients(l, g, g.x, g.e, rtol = RTOL_HIGH)
-#     end
+    edim = 10
+    l = CGConv((D_IN, edim) => D_OUT, tanh, residual = false, bias = true)
+    for g in TEST_GRAPHS
+        g = GNNGraph(g, edata = rand(Float32, edim, g.num_edges))
+        @test size(l(g, g.x, g.e)) == (D_OUT, g.num_nodes)
+        test_gradients(l, g, g.x, g.e, rtol = RTOL_HIGH)
+    end
 
-#     # no edge features
-#     l1 = CGConv(D_IN => D_OUT, tanh, residual = false, bias = true)
-#     g1 = TEST_GRAPHS[1]
-#     @test l1(g1, g1.ndata.x) == l1(g1).ndata.x
-#     @test l1(g1, g1.ndata.x, nothing) == l1(g1).ndata.x
-# end
+    # no edge features
+    l1 = CGConv(D_IN => D_OUT, tanh, residual = false, bias = true)
+    g1 = TEST_GRAPHS[1]
+    @test l1(g1, g1.ndata.x) == l1(g1).ndata.x
+    @test l1(g1, g1.ndata.x, nothing) == l1(g1).ndata.x
+end
 
 # @testitem "CGConv GPU" setup=[TolSnippet, TestModule] tags=[:gpu] begin
 #     using .TestModule
@@ -458,31 +457,30 @@ end
     end   
 end
 
-## TODO segfault on julia v1.12
-# @testitem "GMMConv" setup=[TolSnippet, TestModule] begin
-#     using .TestModule
-#     ein_channel = 10
-#     K = 5
-#     l = GMMConv((D_IN, ein_channel) => D_OUT, K = K)
-#     for g in TEST_GRAPHS
-#         g = GNNGraph(g, edata = rand(Float32, ein_channel, g.num_edges))
-#         y = l(g, g.x, g.e)
-#         test_gradients(l, g, g.x, g.e, rtol = RTOL_HIGH)
-#     end
-# end
+@testitem "GMMConv" setup=[TolSnippet, TestModule] begin
+    using .TestModule
+    ein_channel = 10
+    K = 5
+    l = GMMConv((D_IN, ein_channel) => D_OUT, K = K)
+    for g in TEST_GRAPHS
+        g = GNNGraph(g, edata = rand(Float32, ein_channel, g.num_edges))
+        y = l(g, g.x, g.e)
+        test_gradients(l, g, g.x, g.e, rtol = RTOL_HIGH)
+    end
+end
 
-# @testitem "GMMConv GPU" setup=[TolSnippet, TestModule] tags=[:gpu] begin
-#     using .TestModule
-#     ein_channel = 10
-#     K = 5
-#     l = GMMConv((D_IN, ein_channel) => D_OUT, K = K)
-#     for g in TEST_GRAPHS
-#         g.graph isa AbstractSparseMatrix && continue
-#         g = GNNGraph(g, edata = rand(Float32, ein_channel, g.num_edges))
-#         y = l(g, g.x, g.e)
-#         test_gradients(l, g, g.x, g.e, rtol = RTOL_HIGH, test_gpu = true)
-#     end   
-# end
+@testitem "GMMConv GPU" setup=[TolSnippet, TestModule] tags=[:gpu] begin
+    using .TestModule
+    ein_channel = 10
+    K = 5
+    l = GMMConv((D_IN, ein_channel) => D_OUT, K = K)
+    for g in TEST_GRAPHS
+        g.graph isa AbstractSparseMatrix && continue
+        g = GNNGraph(g, edata = rand(Float32, ein_channel, g.num_edges))
+        y = l(g, g.x, g.e)
+        test_gradients(l, g, g.x, g.e, rtol = RTOL_HIGH, test_gpu = true)
+    end
+end
 
 @testitem "SGConv" setup=[TolSnippet, TestModule] begin
     using .TestModule


### PR DESCRIPTION
Fixes #623.

## Problem

`CGConv` and `GMMConv` gradients segfault on Julia 1.12 (`test_gradients` was disabled for both in all frontends). Reducing the failure to a dependency-free MWE shows the trigger is a **logging macro (`@warn`/`@info`) inside a Zygote-differentiated branch**, which crashes Julia's LLVM codegen (`emit_condition` → `emit_unbox` → `getType`) while compiling the generated pullback:

```julia
using Zygote
f(x) = x > 0 ? x * 2 : (@warn "neg"; x)
Zygote.gradient(f, 1.0f0)   # => Segmentation fault: 11 on Julia 1.12
```

Replacing `@warn` with `println` makes it pass. Reported upstream as [FluxML/Zygote.jl#1662]. Both layers had a `@warn` in their residual branch, which was the exact trigger.

## Fix

Wrap the two `@warn` calls (in `cg_conv` and `gmm_conv`) in `ignore_derivatives` so the logging macro stays out of the AD-differentiated code path. The warning still fires in the forward pass and the primal value is unchanged.

The previously disabled `CGConv`/`GMMConv` gradient test items are re-enabled in both the Flux and Lux frontends.

## Verification

On Julia 1.12.6 / Zygote 0.7.11, the re-enabled Flux items pass the full `test_gradients` suite (finite differences + Zygote + Mooncake, across all `TEST_GRAPHS`): **CGConv 18/18**, **GMMConv 8/8**, no segfault.

[FluxML/Zygote.jl#1662]: https://github.com/FluxML/Zygote.jl/issues/1662

🤖 Generated with [Claude Code](https://claude.com/claude-code)