### PR TITLE
Learnable epsilon in GIN

### DIFF
--- a/GNNLux/src/layers/conv.jl
+++ b/GNNLux/src/layers/conv.jl
@@ -1287,7 +1287,7 @@ function Base.show(io::IO, l::GatedGraphConv)
 end
 
 @doc raw"""
-    GINConv(f, [eps]; aggr=+, train_eps=false)
+    GINConv(f, [ϵ]; aggr=+, train_eps=false)
 
 Graph Isomorphism convolutional layer from paper [How Powerful are Graph Neural Networks?](https://arxiv.org/pdf/1810.00826.pdf).
 
@@ -1300,7 +1300,7 @@ where ``f_\Theta`` typically denotes a learnable function, e.g. a linear layer o
 # Arguments
 
 - `f`: A (possibly learnable) function acting on node features. 
-- `eps`: Initial value of the weighting factor ``\epsilon``. Default `0.0f0`.
+- `ϵ`: Initial value of the weighting factor ``\epsilon``. Default `0.0f0`.
 - `train_eps`: If `true`, ``\epsilon`` is trainable. Default `false`.
 - `aggr`: Neighborhood aggregation function. Default `+`.
 
@@ -1324,7 +1324,7 @@ x = randn(rng, Float32, in_channel, g.num_nodes)
 nn = Dense(in_channel, out_channel)
 
 # create layer
-l = GINConv(nn; eps = 0.01f0, train_eps = true, aggr = mean)
+l = GINConv(nn; ϵ = 0.01f0, train_eps = true, aggr = mean)
 
 # setup layer
 ps, st = LuxCore.setup(rng, l)
@@ -1335,22 +1335,22 @@ y, st = l(g, x, ps, st)       # size:  out_channel × num_nodes
 """
 @concrete struct GINConv <: GNNContainerLayer{(:nn,)}
     nn <: AbstractLuxLayer
-    eps
+    ϵ
     aggr
     train_eps::Bool
 end
 
-GINConv(nn, eps::Real; aggr = +, train_eps::Bool = false) =
-    GINConv(nn, train_eps ? [eps] : eps, aggr, train_eps)
+GINConv(nn, ϵ::Real; aggr = +, train_eps::Bool = false) =
+    GINConv(nn, train_eps ? [ϵ] : ϵ, aggr, train_eps)
 
-GINConv(nn, eps::Real, aggr) = GINConv(nn, eps; aggr)
+GINConv(nn, ϵ::Real, aggr) = GINConv(nn, ϵ; aggr)
 
-GINConv(nn; eps::Real = 0.0f0, aggr = +, train_eps::Bool = false) =
-    GINConv(nn, eps; aggr, train_eps)
+GINConv(nn; ϵ::Real = 0.0f0, aggr = +, train_eps::Bool = false) =
+    GINConv(nn, ϵ; aggr, train_eps)
 
 function LuxCore.initialparameters(rng::AbstractRNG, l::GINConv)
     nn = LuxCore.initialparameters(rng, l.nn)
-    return l.train_eps ? (; nn, eps = l.eps) : (; nn)
+    return l.train_eps ? (; nn, ϵ = l.ϵ) : (; nn)
 end
 
 LuxCore.parameterlength(l::GINConv) = parameterlength(l.nn) + l.train_eps
@@ -1358,8 +1358,8 @@ LuxCore.statelength(l::GINConv) = statelength(l.nn)
 
 function (l::GINConv)(g, x, ps, st)
     nn = StatefulLuxLayer{true}(l.nn, ps.nn, st.nn)
-    eps = l.train_eps ? ps.eps : l.eps
-    m = (; nn, eps, l.aggr)
+    ϵ = l.train_eps ? ps.ϵ : l.ϵ
+    m = (; nn, ϵ, l.aggr)
     y = GNNlib.gin_conv(m, g, x)
     stnew = (; nn = _getstate(nn))
     return y, stnew
@@ -1367,7 +1367,7 @@ end
 
 function Base.show(io::IO, l::GINConv)
     print(io, "GINConv($(l.nn)")
-    print(io, ", eps=$(l.eps)")
+    print(io, ", ϵ=$(l.ϵ)")
     l.train_eps && print(io, ", train_eps=true")
     l.aggr == (+) || print(io, ", aggr=$(l.aggr)")
     print(io, ")")

--- a/GNNLux/src/layers/conv.jl
+++ b/GNNLux/src/layers/conv.jl
@@ -1277,7 +1277,7 @@ function Base.show(io::IO, l::GatedGraphConv)
 end
 
 @doc raw"""
-    GINConv(f, ϵ; aggr=+)
+    GINConv(f, [eps]; aggr=+, train_eps=false)
 
 Graph Isomorphism convolutional layer from paper [How Powerful are Graph Neural Networks?](https://arxiv.org/pdf/1810.00826.pdf).
 
@@ -1290,7 +1290,9 @@ where ``f_\Theta`` typically denotes a learnable function, e.g. a linear layer o
 # Arguments
 
 - `f`: A (possibly learnable) function acting on node features. 
-- `ϵ`: Weighting factor.
+- `eps`: Initial value of the weighting factor ``\epsilon``. Default `0.0f0`.
+- `train_eps`: If `true`, ``\epsilon`` is trainable. Default `false`.
+- `aggr`: Neighborhood aggregation function. Default `+`.
 
 # Examples:
 
@@ -1312,7 +1314,7 @@ x = randn(rng, Float32, in_channel, g.num_nodes)
 nn = Dense(in_channel, out_channel)
 
 # create layer
-l = GINConv(nn, 0.01f0, aggr = mean)
+l = GINConv(nn; eps = 0.01f0, train_eps = true, aggr = mean)
 
 # setup layer
 ps, st = LuxCore.setup(rng, l)
@@ -1323,15 +1325,31 @@ y, st = l(g, x, ps, st)       # size:  out_channel × num_nodes
 """
 @concrete struct GINConv <: GNNContainerLayer{(:nn,)}
     nn <: AbstractLuxLayer
-    ϵ <: Real
+    eps
     aggr
+    train_eps::Bool
 end
 
-GINConv(nn, ϵ; aggr = +) = GINConv(nn, ϵ, aggr)
+GINConv(nn, eps::Real; aggr = +, train_eps::Bool = false) =
+    GINConv(nn, train_eps ? [eps] : eps, aggr, train_eps)
+
+GINConv(nn, eps::Real, aggr) = GINConv(nn, eps; aggr)
+
+GINConv(nn; eps::Real = 0.0f0, aggr = +, train_eps::Bool = false) =
+    GINConv(nn, eps; aggr, train_eps)
+
+function LuxCore.initialparameters(rng::AbstractRNG, l::GINConv)
+    nn = LuxCore.initialparameters(rng, l.nn)
+    return l.train_eps ? (; nn, eps = l.eps) : (; nn)
+end
+
+LuxCore.parameterlength(l::GINConv) = parameterlength(l.nn) + l.train_eps
+LuxCore.statelength(l::GINConv) = statelength(l.nn)
 
 function (l::GINConv)(g, x, ps, st)
     nn = StatefulLuxLayer{true}(l.nn, ps.nn, st.nn)
-    m = (; nn, l.ϵ, l.aggr)
+    eps = l.train_eps ? ps.eps : l.eps
+    m = (; nn, eps, l.aggr)
     y = GNNlib.gin_conv(m, g, x)
     stnew = (; nn = _getstate(nn))
     return y, stnew
@@ -1339,7 +1357,9 @@ end
 
 function Base.show(io::IO, l::GINConv)
     print(io, "GINConv($(l.nn)")
-    print(io, ", $(l.ϵ)")
+    print(io, ", eps=$(l.eps)")
+    l.train_eps && print(io, ", train_eps=true")
+    l.aggr == (+) || print(io, ", aggr=$(l.aggr)")
     print(io, ")")
 end
 

--- a/GNNLux/test/layers/conv.jl
+++ b/GNNLux/test/layers/conv.jl
@@ -93,8 +93,17 @@
 
     @testset "GINConv" begin
         nn = Chain(Dense(in_dims => out_dims, tanh), Dense(out_dims => out_dims))
-        l = GINConv(nn, 0.5)
+        l = GINConv(nn; eps = 0.5)
         test_lux_layer(rng, l, g, x, sizey=(out_dims,g.num_nodes), container=true)
+        ps = LuxCore.initialparameters(rng, l)
+        @test !hasproperty(ps, :eps)
+
+        l = GINConv(nn; train_eps = true)
+        test_lux_layer(rng, l, g, x, sizey=(out_dims,g.num_nodes), container=true)
+        ps = LuxCore.initialparameters(rng, l)
+        @test ps.eps == [0.0f0]
+
+        @test GINConv(nn, 0.5).eps == 0.5
     end
 
     @testset "MEGNetConv" begin

--- a/GNNLux/test/layers/conv.jl
+++ b/GNNLux/test/layers/conv.jl
@@ -92,17 +92,17 @@
 
     @testset "GINConv" begin
         nn = Chain(Dense(in_dims => out_dims, tanh), Dense(out_dims => out_dims))
-        l = GINConv(nn; eps = 0.5)
+        l = GINConv(nn; ϵ = 0.5)
         test_lux_layer(rng, l, g, x, sizey=(out_dims,g.num_nodes), container=true)
         ps = LuxCore.initialparameters(rng, l)
-        @test !hasproperty(ps, :eps)
+        @test !hasproperty(ps, :ϵ)
 
         l = GINConv(nn; train_eps = true)
         test_lux_layer(rng, l, g, x, sizey=(out_dims,g.num_nodes), container=true)
         ps = LuxCore.initialparameters(rng, l)
-        @test ps.eps == [0.0f0]
+        @test ps.ϵ == [0.0f0]
 
-        @test GINConv(nn, 0.5).eps == 0.5
+        @test GINConv(nn, 0.5).ϵ == 0.5
     end
 
     @testset "MEGNetConv" begin

--- a/GNNlib/src/layers/conv.jl
+++ b/GNNlib/src/layers/conv.jl
@@ -252,7 +252,7 @@ function gin_conv(l, g::AbstractGNNGraph, x)
     xj, xi = expand_srcdst(g, x) 
  
     m = propagate(copy_xj, g, l.aggr, xj = xj)
-    ϵ = convert.(float(eltype(xi)), l.ϵ)
+    ϵ = l.ϵ isa Real ? ofeltype(xi, l.ϵ) : l.ϵ
     return l.nn((1 .+ ϵ) .* xi .+ m)
 end
 

--- a/GNNlib/src/layers/conv.jl
+++ b/GNNlib/src/layers/conv.jl
@@ -252,7 +252,8 @@ function gin_conv(l, g::AbstractGNNGraph, x)
     xj, xi = expand_srcdst(g, x) 
  
     m = propagate(copy_xj, g, l.aggr, xj = xj)
-    return l.nn((1 .+ ofeltype(xi, l.ϵ)) .* xi .+ m)
+    eps = convert.(float(eltype(xi)), l.eps)
+    return l.nn((1 .+ eps) .* xi .+ m)
 end
 
 ####################### NNConv ######################################

--- a/GNNlib/src/layers/conv.jl
+++ b/GNNlib/src/layers/conv.jl
@@ -252,8 +252,8 @@ function gin_conv(l, g::AbstractGNNGraph, x)
     xj, xi = expand_srcdst(g, x) 
  
     m = propagate(copy_xj, g, l.aggr, xj = xj)
-    eps = convert.(float(eltype(xi)), l.eps)
-    return l.nn((1 .+ eps) .* xi .+ m)
+    ϵ = convert.(float(eltype(xi)), l.ϵ)
+    return l.nn((1 .+ ϵ) .* xi .+ m)
 end
 
 ####################### NNConv ######################################

--- a/GraphNeuralNetworks/src/layers/conv.jl
+++ b/GraphNeuralNetworks/src/layers/conv.jl
@@ -590,7 +590,7 @@ function Base.show(io::IO, l::EdgeConv)
 end
 
 @doc raw"""
-    GINConv(f, [eps]; aggr=+, train_eps=false)
+    GINConv(f, [ϵ]; aggr=+, train_eps=false)
 
 Graph Isomorphism convolutional layer from paper [How Powerful are Graph Neural Networks?](https://arxiv.org/pdf/1810.00826.pdf).
 
@@ -603,7 +603,7 @@ where ``f_\Theta`` typically denotes a learnable function, e.g. a linear layer o
 # Arguments
 
 - `f`: A (possibly learnable) function acting on node features. 
-- `eps`: Initial value of the weighting factor ``\epsilon``. Default `0.0f0`.
+- `ϵ`: Initial value of the weighting factor ``\epsilon``. Default `0.0f0`.
 - `train_eps`: If `true`, ``\epsilon`` is trainable. Default `false`.
 - `aggr`: Neighborhood aggregation function. Default `+`.
 
@@ -621,7 +621,7 @@ g = GNNGraph(s, t)
 nn = Dense(in_channel, out_channel)
 
 # create layer
-l = GINConv(nn; eps = 0.01f0, train_eps = true, aggr = mean)
+l = GINConv(nn; ϵ = 0.01f0, train_eps = true, aggr = mean)
 
 # forward pass
 y = l(g, x)  
@@ -629,27 +629,27 @@ y = l(g, x)
 """
 struct GINConv{E, NN, A} <: GNNLayer
     nn::NN
-    eps::E
+    ϵ::E
     aggr::A
     train_eps::Bool
 end
 
 Flux.@layer :expand GINConv
-Flux.trainable(l::GINConv) = l.train_eps ? (; l.nn, l.eps) : (; l.nn)
+Flux.trainable(l::GINConv) = l.train_eps ? (; l.nn, l.ϵ) : (; l.nn)
 
-GINConv(nn, eps::Real; aggr = +, train_eps::Bool = false) =
-    GINConv(nn, train_eps ? [eps] : eps, aggr, train_eps)
+GINConv(nn, ϵ::Real; aggr = +, train_eps::Bool = false) =
+    GINConv(nn, train_eps ? [ϵ] : ϵ, aggr, train_eps)
 
-GINConv(nn, eps::Real, aggr) = GINConv(nn, eps; aggr)
+GINConv(nn, ϵ::Real, aggr) = GINConv(nn, ϵ; aggr)
 
-GINConv(nn; eps::Real = 0.0f0, aggr = +, train_eps::Bool = false) =
-    GINConv(nn, eps; aggr, train_eps)
+GINConv(nn; ϵ::Real = 0.0f0, aggr = +, train_eps::Bool = false) =
+    GINConv(nn, ϵ; aggr, train_eps)
 
 (l::GINConv)(g, x) = GNNlib.gin_conv(l, g, x)
 
 function Base.show(io::IO, l::GINConv)
     print(io, "GINConv($(l.nn)")
-    print(io, ", eps=$(l.eps)")
+    print(io, ", ϵ=$(l.ϵ)")
     l.train_eps && print(io, ", train_eps=true")
     l.aggr == (+) || print(io, ", aggr=$(l.aggr)")
     print(io, ")")

--- a/GraphNeuralNetworks/src/layers/conv.jl
+++ b/GraphNeuralNetworks/src/layers/conv.jl
@@ -590,7 +590,7 @@ function Base.show(io::IO, l::EdgeConv)
 end
 
 @doc raw"""
-    GINConv(f, ϵ; aggr=+)
+    GINConv(f, [eps]; aggr=+, train_eps=false)
 
 Graph Isomorphism convolutional layer from paper [How Powerful are Graph Neural Networks?](https://arxiv.org/pdf/1810.00826.pdf).
 
@@ -603,7 +603,9 @@ where ``f_\Theta`` typically denotes a learnable function, e.g. a linear layer o
 # Arguments
 
 - `f`: A (possibly learnable) function acting on node features. 
-- `ϵ`: Weighting factor.
+- `eps`: Initial value of the weighting factor ``\epsilon``. Default `0.0f0`.
+- `train_eps`: If `true`, ``\epsilon`` is trainable. Default `false`.
+- `aggr`: Neighborhood aggregation function. Default `+`.
 
 # Examples:
 
@@ -619,28 +621,37 @@ g = GNNGraph(s, t)
 nn = Dense(in_channel, out_channel)
 
 # create layer
-l = GINConv(nn, 0.01f0, aggr = mean)
+l = GINConv(nn; eps = 0.01f0, train_eps = true, aggr = mean)
 
 # forward pass
 y = l(g, x)  
 ```
 """
-struct GINConv{R <: Real, NN, A} <: GNNLayer
+struct GINConv{E, NN, A} <: GNNLayer
     nn::NN
-    ϵ::R
+    eps::E
     aggr::A
+    train_eps::Bool
 end
 
 Flux.@layer :expand GINConv
-Flux.trainable(l::GINConv) = (nn = l.nn,)
+Flux.trainable(l::GINConv) = l.train_eps ? (; l.nn, l.eps) : (; l.nn)
 
-GINConv(nn, ϵ; aggr = +) = GINConv(nn, ϵ, aggr)
+GINConv(nn, eps::Real; aggr = +, train_eps::Bool = false) =
+    GINConv(nn, train_eps ? [eps] : eps, aggr, train_eps)
+
+GINConv(nn, eps::Real, aggr) = GINConv(nn, eps; aggr)
+
+GINConv(nn; eps::Real = 0.0f0, aggr = +, train_eps::Bool = false) =
+    GINConv(nn, eps; aggr, train_eps)
 
 (l::GINConv)(g, x) = GNNlib.gin_conv(l, g, x)
 
 function Base.show(io::IO, l::GINConv)
     print(io, "GINConv($(l.nn)")
-    print(io, ", $(l.ϵ)")
+    print(io, ", eps=$(l.eps)")
+    l.train_eps && print(io, ", train_eps=true")
+    l.aggr == (+) || print(io, ", aggr=$(l.aggr)")
     print(io, ")")
 end
 

--- a/GraphNeuralNetworks/test/layers/conv.jl
+++ b/GraphNeuralNetworks/test/layers/conv.jl
@@ -278,19 +278,31 @@ end
     using .TestModule
     nn = Dense(D_IN, D_OUT)
 
-    l = GINConv(nn, 0.01, aggr = mean)
+    l = GINConv(nn; eps = 0.01, aggr = mean)
     for g in TEST_GRAPHS
         @test size(l(g, g.x)) == (D_OUT, g.num_nodes)
         test_gradients(l, g, g.x, rtol = RTOL_HIGH)
     end
+    @test keys(Flux.trainable(l)) == (:nn,)
 
-    @test !in(:eps, Flux.trainable(l))
+    l = GINConv(Dense(D_IN, D_OUT); train_eps = true, aggr = mean)
+    @test keys(Flux.trainable(l)) == (:nn, :eps)
+    @test l.eps == [0.0f0]
+    for g in TEST_GRAPHS
+        @test size(l(g, g.x)) == (D_OUT, g.num_nodes)
+    end
+    g = first(TEST_GRAPHS)
+    grad = Flux.gradient(l -> mean(l(g, g.x)), l)[1]
+    @test grad.eps isa AbstractVector
+    @test length(grad.eps) == 1
+
+    @test GINConv(nn, 0.5).eps == 0.5
 end
 
 @testitem "GINConv GPU" setup=[TolSnippet, TestModule] tags=[:gpu] begin
     using .TestModule
     nn = Dense(D_IN, D_OUT)
-    l = GINConv(nn, 0.01, aggr = mean)
+    l = GINConv(nn; train_eps = true, aggr = mean)
     for g in TEST_GRAPHS
         g.graph isa AbstractSparseMatrix && continue
         @test size(l(g, g.x)) == (D_OUT, g.num_nodes)

--- a/GraphNeuralNetworks/test/layers/conv.jl
+++ b/GraphNeuralNetworks/test/layers/conv.jl
@@ -278,7 +278,7 @@ end
     using .TestModule
     nn = Dense(D_IN, D_OUT)
 
-    l = GINConv(nn; eps = 0.01, aggr = mean)
+    l = GINConv(nn; ϵ = 0.01, aggr = mean)
     for g in TEST_GRAPHS
         @test size(l(g, g.x)) == (D_OUT, g.num_nodes)
         test_gradients(l, g, g.x, rtol = RTOL_HIGH)
@@ -286,17 +286,17 @@ end
     @test keys(Flux.trainable(l)) == (:nn,)
 
     l = GINConv(Dense(D_IN, D_OUT); train_eps = true, aggr = mean)
-    @test keys(Flux.trainable(l)) == (:nn, :eps)
-    @test l.eps == [0.0f0]
+    @test keys(Flux.trainable(l)) == (:nn, :ϵ)
+    @test l.ϵ == [0.0f0]
     for g in TEST_GRAPHS
         @test size(l(g, g.x)) == (D_OUT, g.num_nodes)
     end
     g = first(TEST_GRAPHS)
     grad = Flux.gradient(l -> mean(l(g, g.x)), l)[1]
-    @test grad.eps isa AbstractVector
-    @test length(grad.eps) == 1
+    @test grad.ϵ isa AbstractVector
+    @test length(grad.ϵ) == 1
 
-    @test GINConv(nn, 0.5).eps == 0.5
+    @test GINConv(nn, 0.5).ϵ == 0.5
 end
 
 @testitem "GINConv GPU" setup=[TolSnippet, TestModule] tags=[:gpu] begin


### PR DESCRIPTION
This PR adds [PyTorch Geometric-style](https://pytorch-geometric.readthedocs.io/en/2.4.0/generated/torch_geometric.nn.conv.GINConv.html?highlight=gin+conv#torch_geometric.nn.conv.GINConv) ` ϵ ` and `train_eps` options to `GINConv` for both Flux and Lux.

```julia
GINConv(nn; train_eps = true)  # trainable eps, initialized to 0
GINConv(nn;  ϵ  = 0.1f0)       # fixed eps