### PR TITLE
Slice GNNRecurrence input by indexing instead of eachslice views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Entries link to the pull request that introduced them.
 ## GraphNeuralNetworks.jl — Unreleased (towards 1.1.1)
 
 **Changed**
+- `GNNRecurrence` now hands each cell an indexed time slice instead of an `eachslice` view, matching the Lux frontend. Enzyme's type analysis fails on `SubArray` cell inputs, so this unblocks `DCGRU`, `EvolveGCNO`, `GConvGRU` and `GConvLSTM` under Enzyme ([#707]).
 - The recurrent temporal cells now delegate their forward-pass math to shared `GNNlib` functions (requires GNNlib ≥ 1.4); the layer behaviour is unchanged ([#696]).
 
 ## GNNlib.jl 1.4.0 — 2026-07-22
@@ -234,4 +235,5 @@ Lux implementations of the graph convolutional, pooling, and temporal layers
 [#696]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/696
 [#703]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/703
 [#704]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/704
+[#707]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/707
 [FluxML/Zygote.jl#1662]: https://github.com/FluxML/Zygote.jl/issues/1662

--- a/GraphNeuralNetworks/src/layers/temporalconv.jl
+++ b/GraphNeuralNetworks/src/layers/temporalconv.jl
@@ -1,7 +1,9 @@
 function scan(cell, g::GNNGraph, x::AbstractArray{T,3}, state) where {T}
     y = []
-    for xt in eachslice(x, dims = 2)
-        yt, state = cell(g, xt, state)
+    for t in 1:size(x, 2)
+        # slice by indexing, not `eachslice`: Enzyme's type analysis fails on
+        # `SubArray` cell inputs. The Lux frontend slices the same way.
+        yt, state = cell(g, x[:, t, :], state)
         y = vcat(y, [yt])
     end
     return stack(y, dims = 2)


### PR DESCRIPTION
Enzyme's type analysis fails when a recurrent cell receives a `SubArray` view of the
3-d input (`DCGRUCell` on a plain matrix passes; the same cell inside `GNNRecurrence`
fails). Indexing the time slice instead of using `eachslice` fixes this and matches
how the Lux frontend already slices. The copy is one `features × nodes` slice per step.

Verified under Enzyme: `DCGRU`, `EvolveGCNO`, `GConvGRU` and `GConvLSTM` now match
Zygote (the latter two also need #706). Zygote/Mooncake temporal tests: 60/60.

Note: `TGCN` remains unsupported under Enzyme — with the view failure gone it runs into
`TGCNCell`'s known compile hang, so it must stay excluded from Enzyme test runs.
